### PR TITLE
manifest v3 csp fix

### DIFF
--- a/src/devBuilder/devBuilder.ts
+++ b/src/devBuilder/devBuilder.ts
@@ -64,7 +64,9 @@ export default abstract class DevBuilder<
       this.hmrServerOrigin,
     ];
 
-    const cspHmrScriptSrc = `script-src ${scriptSrcs.join(" ")}`;
+    const cspHmrScriptSrc = `script-src ${scriptSrcs.join(
+      " "
+    )}; object-src 'self'`;
 
     if (!contentSecurityPolicy) {
       return cspHmrScriptSrc;

--- a/src/devBuilder/devBuilderManifestV2.ts
+++ b/src/devBuilder/devBuilderManifestV2.ts
@@ -1,8 +1,7 @@
+import crypto from "crypto";
 import DevBuilder from "./devBuilder";
 
 export default class DevBuilderManifestV2 extends DevBuilder<chrome.runtime.ManifestV2> {
-  protected async writeBuildFiles(): Promise<void> {}
-
   protected updateContentSecurityPolicyForHmr(
     manifest: chrome.runtime.ManifestV2
   ): chrome.runtime.ManifestV2 {
@@ -12,5 +11,15 @@ export default class DevBuilderManifestV2 extends DevBuilder<chrome.runtime.Mani
       );
 
     return manifest;
+  }
+
+  protected parseInlineScriptHashes(content: string) {
+    const matches = content.matchAll(/<script.*?>([^<]+)<\/script>/gs);
+    for (const match of matches) {
+      const shasum = crypto.createHash("sha256");
+      shasum.update(match[1]);
+
+      this.inlineScriptHashes.add(`'sha256-${shasum.digest("base64")}'`);
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,11 +50,10 @@ export default function webExtension(
     },
 
     configureServer(server) {
-      manifestParser.setDevServer(server);
-
       server.middlewares.use(contentScriptStyleHandler);
 
       server.httpServer!.once("listening", () => {
+        manifestParser.setDevServer(server);
         manifestParser.writeDevBuild(server.config.server.port!);
       });
     },


### PR DESCRIPTION
- fix: ensure dev server is set for dev builds, add object-src to dev CSP
- fix: only set script hashes in manifest V2 CSP
