### PR TITLE
fix: multiple css dependencies in content scripts, shared css across chunks

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,36 @@
+# Migration
+
+- [Version 0.x.x to 1.0.0](#version-0xx-to-100)
+
+## Version 0.x.x to 1.0.0
+
+- Upgrade Vite to 2.9.x
+
+  - Upgrade any vite framework plugins as well
+
+- Replace usages of `import.meta.CURRENT_CONTENT_SCRIPT_CSS_URL` with `import.meta.PLUGIN_WEB_EXT_CHUNK_CSS_PATHS`
+
+  - `import.meta.PLUGIN_WEB_EXT_CHUNK_CSS_PATHS` is replaced with an array of css paths at build time, so update existing code that expects a single string to properly handle an array of strings.
+
+- Replace usages of `addStyleTarget` from `/@vite/client` with `addViteStyleTarget` from `@samrum/vite-plugin-web-extension/client`:
+
+  ```js
+  const { addStyleTarget } = await import("/@vite/client");
+
+  addStyleTarget(shadowRoot);
+  ```
+
+  to
+
+  ```js
+  const { addViteStyleTarget } = await import(
+    "@samrum/vite-plugin-web-extension/client"
+  );
+
+  await addViteStyleTarget(shadowRoot);
+  ```
+
+- If using TypeScript, add plugin client types to your `env.d.ts` file:
+  ```ts
+  /// <reference types="@samrum/vite-plugin-web-extension/client" />
+  ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Supports choice of Manifest, TypeScript, and framework (Vanilla, Vue, React, Pre
 
 ## Manual Install
 
+Requires Vite 2.9+
+
 ```sh
 npm install @samrum/vite-plugin-web-extension
 ```
@@ -95,17 +97,19 @@ npm install @samrum/vite-plugin-web-extension
 
   ```js
   if (import.meta.hot) {
-    const { addStyleTarget } = await import("/@vite/client");
+    const { addViteStyleTarget } = await import(
+      "@samrum/vite-plugin-web-extension/client"
+    );
 
-    addStyleTarget(shadowRoot);
+    await addViteStyleTarget(appContainer);
   }
   ```
 
-- For builds, use the `import.meta.CURRENT_CONTENT_SCRIPT_CSS_URL` constant to reference the first generated CSS file associated with the current content script chunk.
+- For builds, use the `import.meta.PLUGIN_WEB_EXT_CHUNK_CSS_PATHS` variable to reference an array of CSS asset paths associated with the current output chunk.
 
 #### TypeScript
 
-In an [env.d.ts file](https://vitejs.dev/guide/env-and-mode.html#intellisense-for-typescript), add the following type reference to define the plugin specific `import.meta` values:
+In an [env.d.ts file](https://vitejs.dev/guide/env-and-mode.html#intellisense-for-typescript), add the following type reference to define the plugin specific `import.meta` variables as well as plugin client functions:
 
 ```ts
 /// <reference types="@samrum/vite-plugin-web-extension/client" />

--- a/client.d.ts
+++ b/client.d.ts
@@ -1,3 +1,7 @@
 interface ImportMeta {
-  CURRENT_CONTENT_SCRIPT_CSS_URL: string;
+  PLUGIN_WEB_EXT_CHUNK_CSS_PATHS: string[];
+}
+
+declare module "@samrum/vite-plugin-web-extension/client" {
+  export function addViteStyleTarget(element: Node): Promise<void>;
 }

--- a/client.js
+++ b/client.js
@@ -1,0 +1,5 @@
+export async function addViteStyleTarget(element) {
+  const { addStyleTarget } = await import("/@vite/client");
+
+  addStyleTarget(element);
+}

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "node": ">=12.0.0"
   },
   "files": [
-    "dist",
-    "types",
+    "client.js",
     "client.d.ts",
-    "README.md"
+    "dist",
+    "README.md",
+    "types"
   ],
   "scripts": {
     "build": "tsc --noEmit && rollup -c",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript": "^4.4.3"
   },
   "peerDependencies": {
-    "vite": "^2.7.10"
+    "vite": "^2.9.0"
   },
   "lint-staged": {
     "*.{js,ts,css,md}": "prettier --write"
@@ -76,6 +76,6 @@
     "etag": "^1.8.1",
     "fs-extra": "^10.0.0",
     "magic-string": "^0.25.7",
-    "vite": "^2.7.10"
+    "vite": "~2.9.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ specifiers:
   ts-jest: ^27.0.4
   tslib: ^2.3.0
   typescript: ^4.4.3
-  vite: ^2.7.10
+  vite: ~2.9.0
 
 dependencies:
   '@types/chrome': 0.0.174
@@ -27,7 +27,7 @@ dependencies:
   etag: 1.8.1
   fs-extra: 10.0.0
   magic-string: 0.25.7
-  vite: 2.7.10
+  vite: 2.9.0
 
 devDependencies:
   '@rollup/plugin-typescript': 8.2.5_d671d3387afbf1a138cd7f3f4762053b
@@ -1511,163 +1511,212 @@ packages:
       is-arrayish: 0.2.1
     dev: true
 
-  /esbuild-android-arm64/0.13.15:
-    resolution: {integrity: sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==}
+  /esbuild-android-64/0.14.29:
+    resolution: {integrity: sha512-tJuaN33SVZyiHxRaVTo1pwW+rn3qetJX/SRuc/83rrKYtyZG0XfsQ1ao1nEudIt9w37ZSNXR236xEfm2C43sbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-android-arm64/0.14.29:
+    resolution: {integrity: sha512-D74dCv6yYnMTlofVy1JKiLM5JdVSQd60/rQfJSDP9qvRAI0laPXIG/IXY1RG6jobmFMUfL38PbFnCqyI/6fPXg==}
+    engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
     dev: false
     optional: true
 
-  /esbuild-darwin-64/0.13.15:
-    resolution: {integrity: sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==}
+  /esbuild-darwin-64/0.14.29:
+    resolution: {integrity: sha512-+CJaRvfTkzs9t+CjGa0Oa28WoXa7EeLutQhxus+fFcu0MHhsBhlmeWHac3Cc/Sf/xPi1b2ccDFfzGYJCfV0RrA==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /esbuild-darwin-arm64/0.13.15:
-    resolution: {integrity: sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==}
+  /esbuild-darwin-arm64/0.14.29:
+    resolution: {integrity: sha512-5Wgz/+zK+8X2ZW7vIbwoZ613Vfr4A8HmIs1XdzRmdC1kG0n5EG5fvKk/jUxhNlrYPx1gSY7XadQ3l4xAManPSw==}
+    engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: false
     optional: true
 
-  /esbuild-freebsd-64/0.13.15:
-    resolution: {integrity: sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==}
+  /esbuild-freebsd-64/0.14.29:
+    resolution: {integrity: sha512-VTfS7Bm9QA12JK1YXF8+WyYOfvD7WMpbArtDj6bGJ5Sy5xp01c/q70Arkn596aGcGj0TvQRplaaCIrfBG1Wdtg==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
     dev: false
     optional: true
 
-  /esbuild-freebsd-arm64/0.13.15:
-    resolution: {integrity: sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==}
+  /esbuild-freebsd-arm64/0.14.29:
+    resolution: {integrity: sha512-WP5L4ejwLWWvd3Fo2J5mlXvG3zQHaw5N1KxFGnUc4+2ZFZknP0ST63i0IQhpJLgEJwnQpXv2uZlU1iWZjFqEIg==}
+    engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
     dev: false
     optional: true
 
-  /esbuild-linux-32/0.13.15:
-    resolution: {integrity: sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==}
+  /esbuild-linux-32/0.14.29:
+    resolution: {integrity: sha512-4myeOvFmQBWdI2U1dEBe2DCSpaZyjdQtmjUY11Zu2eQg4ynqLb8Y5mNjNU9UN063aVsCYYfbs8jbken/PjyidA==}
+    engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /esbuild-linux-64/0.13.15:
-    resolution: {integrity: sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==}
+  /esbuild-linux-64/0.14.29:
+    resolution: {integrity: sha512-iaEuLhssReAKE7HMwxwFJFn7D/EXEs43fFy5CJeA4DGmU6JHh0qVJD2p/UP46DvUXLRKXsXw0i+kv5TdJ1w5pg==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /esbuild-linux-arm/0.13.15:
-    resolution: {integrity: sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==}
+  /esbuild-linux-arm/0.14.29:
+    resolution: {integrity: sha512-OXa9D9QL1hwrAnYYAHt/cXAuSCmoSqYfTW/0CEY0LgJNyTxJKtqc5mlwjAZAvgyjmha0auS/sQ0bXfGf2wAokQ==}
+    engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /esbuild-linux-arm64/0.13.15:
-    resolution: {integrity: sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==}
+  /esbuild-linux-arm64/0.14.29:
+    resolution: {integrity: sha512-KYf7s8wDfUy+kjKymW3twyGT14OABjGHRkm9gPJ0z4BuvqljfOOUbq9qT3JYFnZJHOgkr29atT//hcdD0Pi7Mw==}
+    engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /esbuild-linux-mips64le/0.13.15:
-    resolution: {integrity: sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==}
+  /esbuild-linux-mips64le/0.14.29:
+    resolution: {integrity: sha512-05jPtWQMsZ1aMGfHOvnR5KrTvigPbU35BtuItSSWLI2sJu5VrM8Pr9Owym4wPvA4153DFcOJ1EPN/2ujcDt54g==}
+    engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /esbuild-linux-ppc64le/0.13.15:
-    resolution: {integrity: sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==}
+  /esbuild-linux-ppc64le/0.14.29:
+    resolution: {integrity: sha512-FYhBqn4Ir9xG+f6B5VIQVbRuM4S6qwy29dDNYFPoxLRnwTEKToIYIUESN1qHyUmIbfO0YB4phG2JDV2JDN9Kgw==}
+    engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /esbuild-netbsd-64/0.13.15:
-    resolution: {integrity: sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==}
+  /esbuild-linux-riscv64/0.14.29:
+    resolution: {integrity: sha512-eqZMqPehkb4nZcffnuOpXJQdGURGd6GXQ4ZsDHSWyIUaA+V4FpMBe+5zMPtXRD2N4BtyzVvnBko6K8IWWr36ew==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-linux-s390x/0.14.29:
+    resolution: {integrity: sha512-o7EYajF1rC/4ho7kpSG3gENVx0o2SsHm7cJ5fvewWB/TEczWU7teDgusGSujxCYcMottE3zqa423VTglNTYhjg==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /esbuild-netbsd-64/0.14.29:
+    resolution: {integrity: sha512-/esN6tb6OBSot6+JxgeOZeBk6P8V/WdR3GKBFeFpSqhgw4wx7xWUqPrdx4XNpBVO7X4Ipw9SAqgBrWHlXfddww==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
     dev: false
     optional: true
 
-  /esbuild-openbsd-64/0.13.15:
-    resolution: {integrity: sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==}
+  /esbuild-openbsd-64/0.14.29:
+    resolution: {integrity: sha512-jUTdDzhEKrD0pLpjmk0UxwlfNJNg/D50vdwhrVcW/D26Vg0hVbthMfb19PJMatzclbK7cmgk1Nu0eNS+abzoHw==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
     dev: false
     optional: true
 
-  /esbuild-sunos-64/0.13.15:
-    resolution: {integrity: sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==}
+  /esbuild-sunos-64/0.14.29:
+    resolution: {integrity: sha512-EfhQN/XO+TBHTbkxwsxwA7EfiTHFe+MNDfxcf0nj97moCppD9JHPq48MLtOaDcuvrTYOcrMdJVeqmmeQ7doTcg==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
     dev: false
     optional: true
 
-  /esbuild-windows-32/0.13.15:
-    resolution: {integrity: sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==}
+  /esbuild-windows-32/0.14.29:
+    resolution: {integrity: sha512-uoyb0YAJ6uWH4PYuYjfGNjvgLlb5t6b3zIaGmpWPOjgpr1Nb3SJtQiK4YCPGhONgfg2v6DcJgSbOteuKXhwqAw==}
+    engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: false
     optional: true
 
-  /esbuild-windows-64/0.13.15:
-    resolution: {integrity: sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==}
+  /esbuild-windows-64/0.14.29:
+    resolution: {integrity: sha512-X9cW/Wl95QjsH8WUyr3NqbmfdU72jCp71cH3pwPvI4CgBM2IeOUDdbt6oIGljPu2bf5eGDIo8K3Y3vvXCCTd8A==}
+    engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: false
     optional: true
 
-  /esbuild-windows-arm64/0.13.15:
-    resolution: {integrity: sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==}
+  /esbuild-windows-arm64/0.14.29:
+    resolution: {integrity: sha512-+O/PI+68fbUZPpl3eXhqGHTGK7DjLcexNnyJqtLZXOFwoAjaXlS5UBCvVcR3o2va+AqZTj8o6URaz8D2K+yfQQ==}
+    engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: false
     optional: true
 
-  /esbuild/0.13.15:
-    resolution: {integrity: sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==}
+  /esbuild/0.14.29:
+    resolution: {integrity: sha512-SQS8cO8xFEqevYlrHt6exIhK853Me4nZ4aMW6ieysInLa0FMAL+AKs87HYNRtR2YWRcEIqoXAHh+Ytt5/66qpg==}
+    engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      esbuild-android-arm64: 0.13.15
-      esbuild-darwin-64: 0.13.15
-      esbuild-darwin-arm64: 0.13.15
-      esbuild-freebsd-64: 0.13.15
-      esbuild-freebsd-arm64: 0.13.15
-      esbuild-linux-32: 0.13.15
-      esbuild-linux-64: 0.13.15
-      esbuild-linux-arm: 0.13.15
-      esbuild-linux-arm64: 0.13.15
-      esbuild-linux-mips64le: 0.13.15
-      esbuild-linux-ppc64le: 0.13.15
-      esbuild-netbsd-64: 0.13.15
-      esbuild-openbsd-64: 0.13.15
-      esbuild-sunos-64: 0.13.15
-      esbuild-windows-32: 0.13.15
-      esbuild-windows-64: 0.13.15
-      esbuild-windows-arm64: 0.13.15
+      esbuild-android-64: 0.14.29
+      esbuild-android-arm64: 0.14.29
+      esbuild-darwin-64: 0.14.29
+      esbuild-darwin-arm64: 0.14.29
+      esbuild-freebsd-64: 0.14.29
+      esbuild-freebsd-arm64: 0.14.29
+      esbuild-linux-32: 0.14.29
+      esbuild-linux-64: 0.14.29
+      esbuild-linux-arm: 0.14.29
+      esbuild-linux-arm64: 0.14.29
+      esbuild-linux-mips64le: 0.14.29
+      esbuild-linux-ppc64le: 0.14.29
+      esbuild-linux-riscv64: 0.14.29
+      esbuild-linux-s390x: 0.14.29
+      esbuild-netbsd-64: 0.14.29
+      esbuild-openbsd-64: 0.14.29
+      esbuild-sunos-64: 0.14.29
+      esbuild-windows-32: 0.14.29
+      esbuild-windows-64: 0.14.29
+      esbuild-windows-arm64: 0.14.29
     dev: false
 
   /escalade/3.1.1:
@@ -2093,6 +2142,13 @@ packages:
     resolution: {integrity: sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==}
     dependencies:
       has: 1.0.3
+    dev: true
+
+  /is-core-module/2.8.1:
+    resolution: {integrity: sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==}
+    dependencies:
+      has: 1.0.3
+    dev: false
 
   /is-fullwidth-code-point/3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -3022,10 +3078,11 @@ packages:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
 
-  /nanoid/3.1.30:
-    resolution: {integrity: sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==}
+  /nanoid/3.3.2:
+    resolution: {integrity: sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+    dev: false
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
@@ -3250,6 +3307,7 @@ packages:
 
   /picocolors/1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    dev: false
 
   /picomatch/2.3.0:
     resolution: {integrity: sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==}
@@ -3286,13 +3344,13 @@ packages:
       semver-compare: 1.0.0
     dev: true
 
-  /postcss/8.4.5:
-    resolution: {integrity: sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==}
+  /postcss/8.4.12:
+    resolution: {integrity: sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.1.30
+      nanoid: 3.3.2
       picocolors: 1.0.0
-      source-map-js: 1.0.1
+      source-map-js: 1.0.2
     dev: false
 
   /prelude-ls/1.1.2:
@@ -3443,6 +3501,16 @@ packages:
     dependencies:
       is-core-module: 2.6.0
       path-parse: 1.0.7
+    dev: true
+
+  /resolve/1.22.0:
+    resolution: {integrity: sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.8.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: false
 
   /restore-cursor/3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
@@ -3566,9 +3634,10 @@ packages:
       is-fullwidth-code-point: 3.0.0
     dev: true
 
-  /source-map-js/1.0.1:
-    resolution: {integrity: sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==}
+  /source-map-js/1.0.2:
+    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
+    dev: false
 
   /source-map-support/0.5.20:
     resolution: {integrity: sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==}
@@ -3767,6 +3836,11 @@ packages:
       has-flag: 4.0.0
       supports-color: 7.2.0
     dev: true
+
+  /supports-preserve-symlinks-flag/1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+    dev: false
 
   /symbol-tree/3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -3977,8 +4051,8 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite/2.7.10:
-    resolution: {integrity: sha512-KEY96ntXUid1/xJihJbgmLZx7QSC2D4Tui0FdS0Old5OokYzFclcofhtxtjDdGOk/fFpPbHv9yw88+rB93Tb8w==}
+  /vite/2.9.0:
+    resolution: {integrity: sha512-5NAnNqzPmZzJvrswZGeTS2JHrBGIzIWJA2hBTTMYuoBVEMh0xwE0b5yyIXFxf7F07hrK4ugX2LJ7q6t7iIbd4Q==}
     engines: {node: '>=12.2.0'}
     hasBin: true
     peerDependencies:
@@ -3993,9 +4067,9 @@ packages:
       stylus:
         optional: true
     dependencies:
-      esbuild: 0.13.15
-      postcss: 8.4.5
-      resolve: 1.20.0
+      esbuild: 0.14.29
+      postcss: 8.4.12
+      resolve: 1.22.0
       rollup: 2.60.1
     optionalDependencies:
       fsevents: 2.3.2

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { EmittedFile, OutputBundle, RenderedChunk } from "rollup";
+import type { EmittedFile, OutputBundle } from "rollup";
 import type { Plugin, ResolvedConfig } from "vite";
 import type { ViteWebExtensionOptions } from "../types";
 import { addInputScriptsToOptionsInput } from "./utils/rollup";
@@ -85,15 +85,6 @@ export default function webExtension(
 
     transform(code) {
       return transformSelfLocationAssets(code, viteConfig);
-    },
-
-    renderChunk(code, chunk, _options) {
-      const importedCss = (chunk as RenderedChunk).viteMetadata.importedCss;
-
-      return code.replace(
-        "import.meta.PLUGIN_WEB_EXT_CHUNK_CSS_PATHS",
-        `[${[...importedCss].map((path) => `"${path}"`).join(",")}]`
-      );
     },
 
     async generateBundle(_options, bundle) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,11 +91,9 @@ export default function webExtension(
       const importedCss = (chunk as RenderedChunk).viteMetadata.importedCss;
 
       if (importedCss.size) {
-        const [cssAsset] = importedCss;
-
         return code.replace(
-          "import.meta.CURRENT_CONTENT_SCRIPT_CSS_URL",
-          `"${cssAsset}"`
+          "import.meta.PLUGIN_WEB_EXT_CHUNK_CSS_PATHS",
+          `[${[...importedCss].map((path) => `"${path}"`).join(",")}]`
         );
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,14 +90,10 @@ export default function webExtension(
     renderChunk(code, chunk, _options) {
       const importedCss = (chunk as RenderedChunk).viteMetadata.importedCss;
 
-      if (importedCss.size) {
-        return code.replace(
-          "import.meta.PLUGIN_WEB_EXT_CHUNK_CSS_PATHS",
-          `[${[...importedCss].map((path) => `"${path}"`).join(",")}]`
-        );
-      }
-
-      return null;
+      return code.replace(
+        "import.meta.PLUGIN_WEB_EXT_CHUNK_CSS_PATHS",
+        `[${[...importedCss].map((path) => `"${path}"`).join(",")}]`
+      );
     },
 
     async generateBundle(_options, bundle) {

--- a/src/manifestParser/manifestParser.ts
+++ b/src/manifestParser/manifestParser.ts
@@ -187,7 +187,7 @@ export default abstract class ManifestParser<
     chunkId: string,
     bundle: OutputBundle,
     includeChunkAsAsset: boolean,
-    metaData: {
+    metadata: {
       css: Set<string>;
       assets: Set<string>;
     } = {
@@ -200,29 +200,29 @@ export default abstract class ManifestParser<
   } {
     const chunkInfo = getChunkInfoFromBundle(bundle, chunkId);
     if (!chunkInfo) {
-      return metaData;
+      return metadata;
     }
 
     if (includeChunkAsAsset) {
-      metaData.assets.add(chunkInfo.fileName);
+      metadata.assets.add(chunkInfo.fileName);
     }
 
-    chunkInfo.viteMetadata.importedCss.forEach(metaData.css.add, metaData.css);
+    chunkInfo.viteMetadata.importedCss.forEach(metadata.css.add, metadata.css);
     chunkInfo.viteMetadata.importedAssets.forEach(
-      metaData.assets.add,
-      metaData.assets
+      metadata.assets.add,
+      metadata.assets
     );
 
     chunkInfo.imports.forEach(
       (chunkId) =>
-        (metaData = this.getMetadataforChunk(chunkId, bundle, true, metaData))
+        (metadata = this.getMetadataforChunk(chunkId, bundle, true, metadata))
     );
 
     chunkInfo.dynamicImports.forEach(
       (chunkId) =>
-        (metaData = this.getMetadataforChunk(chunkId, bundle, true, metaData))
+        (metadata = this.getMetadataforChunk(chunkId, bundle, true, metadata))
     );
 
-    return metaData;
+    return metadata;
   }
 }

--- a/src/manifestParser/manifestV2.ts
+++ b/src/manifestParser/manifestV2.ts
@@ -6,8 +6,6 @@ import {
   getOutputFileName,
   getInputFileName,
 } from "../utils/file";
-import type { Manifest as ViteManifest } from "vite";
-import { OutputBundle } from "rollup";
 import DevBuilderManifestV2 from "../devBuilder/devBuilderManifestV2";
 import ManifestParser from "./manifestParser";
 import DevBuilder from "./../devBuilder/devBuilder";
@@ -36,9 +34,7 @@ export default class ManifestV2 extends ManifestParser<Manifest> {
   }
 
   protected getParseOutputMethods(): ((
-    result: ManifestParseResult,
-    viteManifest: ViteManifest,
-    outputBundle: OutputBundle
+    result: ManifestParseResult
   ) => Promise<ManifestParseResult>)[] {
     return [];
   }
@@ -78,9 +74,7 @@ export default class ManifestV2 extends ManifestParser<Manifest> {
   }
 
   protected async parseOutputContentScripts(
-    result: ManifestParseResult,
-    viteManifest: ViteManifest,
-    outputBundle: OutputBundle
+    result: ManifestParseResult
   ): Promise<ManifestParseResult> {
     const webAccessibleResources = new Set(
       result.manifest.web_accessible_resources ?? []
@@ -90,9 +84,7 @@ export default class ManifestV2 extends ManifestParser<Manifest> {
       script.js?.forEach((scriptFileName, index) => {
         const parsedContentScript = this.parseOutputContentScript(
           scriptFileName,
-          result,
-          viteManifest,
-          outputBundle
+          result
         );
 
         script.js![index] = parsedContentScript.scriptFileName;

--- a/src/manifestParser/manifestV2.ts
+++ b/src/manifestParser/manifestV2.ts
@@ -9,6 +9,7 @@ import {
 import DevBuilderManifestV2 from "../devBuilder/devBuilderManifestV2";
 import ManifestParser from "./manifestParser";
 import DevBuilder from "./../devBuilder/devBuilder";
+import { OutputBundle } from "rollup";
 
 type Manifest = chrome.runtime.ManifestV2;
 type ManifestParseResult = ParseResult<Manifest>;
@@ -74,7 +75,8 @@ export default class ManifestV2 extends ManifestParser<Manifest> {
   }
 
   protected async parseOutputContentScripts(
-    result: ManifestParseResult
+    result: ManifestParseResult,
+    bundle: OutputBundle
   ): Promise<ManifestParseResult> {
     const webAccessibleResources = new Set(
       result.manifest.web_accessible_resources ?? []
@@ -84,7 +86,8 @@ export default class ManifestV2 extends ManifestParser<Manifest> {
       script.js?.forEach((scriptFileName, index) => {
         const parsedContentScript = this.parseOutputContentScript(
           scriptFileName,
-          result
+          result,
+          bundle
         );
 
         script.js![index] = parsedContentScript.scriptFileName;

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -1,4 +1,4 @@
-import { ManifestChunk } from "vite";
+import { RenderedChunk } from "rollup";
 import { getOutputFileName } from "./file";
 
 export function getScriptHtmlLoaderFile(name: string, scriptSrcs: string[]) {
@@ -41,14 +41,15 @@ export function getServiceWorkerLoaderFile(serviceWorkerFileName: string) {
   };
 }
 
-export function getContentScriptLoaderForManifestChunk(
-  manifestChunk: ManifestChunk
+export function getContentScriptLoaderForRenderedChunk(
+  contentScriptFileName: string,
+  chunk: RenderedChunk
 ): { fileName: string; source?: string } {
-  if (!manifestChunk.imports?.length && !manifestChunk.dynamicImports?.length) {
+  if (!chunk.imports.length && !chunk.dynamicImports.length) {
     return {
-      fileName: manifestChunk.file,
+      fileName: chunk.fileName,
     };
   }
 
-  return getContentScriptLoaderFile(manifestChunk.src!, manifestChunk.file);
+  return getContentScriptLoaderFile(contentScriptFileName, chunk.fileName);
 }

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -1,4 +1,4 @@
-import { RenderedChunk } from "rollup";
+import { OutputChunk } from "rollup";
 import { getOutputFileName } from "./file";
 
 export function getScriptHtmlLoaderFile(name: string, scriptSrcs: string[]) {
@@ -41,9 +41,9 @@ export function getServiceWorkerLoaderFile(serviceWorkerFileName: string) {
   };
 }
 
-export function getContentScriptLoaderForRenderedChunk(
+export function getContentScriptLoaderForOutputChunk(
   contentScriptFileName: string,
-  chunk: RenderedChunk
+  chunk: OutputChunk
 ): { fileName: string; source?: string } {
   if (!chunk.imports.length && !chunk.dynamicImports.length) {
     return {

--- a/src/utils/rollup.ts
+++ b/src/utils/rollup.ts
@@ -1,4 +1,5 @@
-import type { InputOptions } from "rollup";
+import type { InputOptions, OutputBundle, OutputChunk } from "rollup";
+import { getNormalizedFileName } from "./file";
 
 export function addInputScriptsToOptionsInput(
   inputScripts: [string, string][],
@@ -37,4 +38,22 @@ function getOptionsInputAsObject(input: InputOptions["input"]): {
   }
 
   return input ?? {};
+}
+
+export function getChunkInfoFromBundle(
+  bundle: OutputBundle,
+  chunkId: string
+): OutputChunk | undefined {
+  const normalizedId = getNormalizedFileName(chunkId);
+
+  return Object.values(bundle).find((chunk) => {
+    if (chunk.type === "asset") {
+      return false;
+    }
+
+    return (
+      chunk.facadeModuleId?.endsWith(normalizedId) ||
+      chunk.fileName.endsWith(normalizedId)
+    );
+  }) as OutputChunk | undefined;
 }

--- a/test/fixture/fixtureUtils.ts
+++ b/test/fixture/fixtureUtils.ts
@@ -60,6 +60,13 @@ export function getExpectedLogFromDynamicChunk(message: string): string {
 `;
 }
 
+export function getExpectedCss(id: string): string {
+  return `#${id} {
+  display: flex;
+}
+`;
+}
+
 export function getPreloadHelper(): string {
   return `null`;
 }

--- a/test/fixture/index/javascript/manifestV2/chunkCssRewrite.ts
+++ b/test/fixture/index/javascript/manifestV2/chunkCssRewrite.ts
@@ -1,0 +1,40 @@
+import { getExpectedCode } from "../shared/chunkCssRewrite";
+
+const resourceDir = "test/fixture/index/javascript/resources/chunkCssRewrite";
+
+const inputManifest = {
+  content_scripts: [
+    {
+      js: [`${resourceDir}/content1.js`],
+      matches: ["https://*/*", "http://*/*"],
+    },
+    {
+      js: [`${resourceDir}/content2.js`],
+      matches: ["https://*/*", "http://*/*"],
+    },
+  ],
+};
+
+const expectedManifest = {
+  content_scripts: [
+    {
+      js: [`assets/${resourceDir}/content1.js`],
+      matches: ["https://*/*", "http://*/*"],
+    },
+    {
+      js: [`assets/${resourceDir}/content2.js`],
+      matches: ["https://*/*", "http://*/*"],
+    },
+  ],
+  web_accessible_resources: [
+    `assets/${resourceDir}/content1.css`,
+    `assets/contentShared.css`,
+    `assets/${resourceDir}/content2.css`,
+  ],
+};
+
+export default {
+  inputManifest,
+  expectedManifest,
+  ...getExpectedCode(resourceDir),
+};

--- a/test/fixture/index/javascript/manifestV2/index.ts
+++ b/test/fixture/index/javascript/manifestV2/index.ts
@@ -1,5 +1,6 @@
 export { default as BackgroundHtml } from "./backgroundHtml";
 export { default as BackgroundScript } from "./backgroundScript";
+export { default as ChunkCssRewrite } from "./chunkCssRewrite";
 export { default as ContentCss } from "./contentCss";
 export { default as ContentWithDynamicImport } from "./contentWithDynamicImport";
 export { default as ContentWithChunkedImport } from "./contentWithChunkedImport";

--- a/test/fixture/index/javascript/resources/chunkCssRewrite/content1.css
+++ b/test/fixture/index/javascript/resources/chunkCssRewrite/content1.css
@@ -1,0 +1,3 @@
+#content1 {
+  display: flex;
+}

--- a/test/fixture/index/javascript/resources/chunkCssRewrite/content1.js
+++ b/test/fixture/index/javascript/resources/chunkCssRewrite/content1.js
@@ -1,0 +1,4 @@
+import "./content1.css";
+import "./contentShared.css";
+
+console.log(import.meta.PLUGIN_WEB_EXT_CHUNK_CSS_PATHS);

--- a/test/fixture/index/javascript/resources/chunkCssRewrite/content2.css
+++ b/test/fixture/index/javascript/resources/chunkCssRewrite/content2.css
@@ -1,0 +1,3 @@
+#content2 {
+  display: flex;
+}

--- a/test/fixture/index/javascript/resources/chunkCssRewrite/content2.js
+++ b/test/fixture/index/javascript/resources/chunkCssRewrite/content2.js
@@ -1,0 +1,4 @@
+import "./content2.css";
+import "./contentShared.css";
+
+console.log(import.meta.PLUGIN_WEB_EXT_CHUNK_CSS_PATHS);

--- a/test/fixture/index/javascript/resources/chunkCssRewrite/contentShared.css
+++ b/test/fixture/index/javascript/resources/chunkCssRewrite/contentShared.css
@@ -1,0 +1,3 @@
+#contentShared {
+  display: flex;
+}

--- a/test/fixture/index/javascript/shared/chunkCssRewrite.ts
+++ b/test/fixture/index/javascript/shared/chunkCssRewrite.ts
@@ -1,0 +1,23 @@
+import { getExpectedCss } from "../../../fixtureUtils";
+
+export function getExpectedCode(resourceDir: string) {
+  const chunkCode = {
+    [`assets/${resourceDir}/content1.js`]: `/* empty css                               */var content1 = "";
+console.log(["assets/test/fixture/index/javascript/resources/chunkCssRewrite/content1.css","assets/contentShared.css"]);
+`,
+    [`assets/${resourceDir}/content2.js`]: `/* empty css                               */var content2 = "";
+console.log(["assets/test/fixture/index/javascript/resources/chunkCssRewrite/content2.css","assets/contentShared.css"]);
+`,
+  };
+
+  const assetCode = {
+    [`assets/${resourceDir}/content1.css`]: getExpectedCss("content1"),
+    [`assets/${resourceDir}/content2.css`]: getExpectedCss("content2"),
+    [`assets/contentShared.css`]: getExpectedCss("contentShared"),
+  };
+
+  return {
+    chunkCode,
+    assetCode,
+  };
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "vite";
+import type { Plugin, ChunkMetadata } from "vite";
 
 interface ViteWebExtensionOptions {
   /**
@@ -15,4 +15,10 @@ export default function webExtension(options?: ViteWebExtensionOptions): Plugin;
 // TODO: Have this automatically included on plugin usage
 interface ImportMeta {
   CURRENT_CONTENT_SCRIPT_CSS_URL?: string;
+}
+
+declare module "rollup" {
+  export interface RenderedChunk {
+    viteMetadata: ChunkMetadata;
+  }
 }


### PR DESCRIPTION
BREAKING CHANGE: `import.meta.CURRENT_CONTENT_SCRIPT_CSS_URL` has been replaced with `import.meta.PLUGIN_WEB_EXT_CHUNK_CSS_PATHS`. Minimum version of Vite is now 2.9.0