### PR TITLE
feat: web accessible scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,28 @@ npm install @samrum/vite-plugin-web-extension
 
 - For builds, use the `import.meta.PLUGIN_WEB_EXT_CHUNK_CSS_PATHS` variable to reference an array of CSS asset paths associated with the current output chunk.
 
+#### Web Accessible Scripts
+
+This plugin will detect scripts under `web_accessible_resources` and apply the same transformations to them as your content scripts. This can be very useful for developers who need to inject scripts into a live page, usually to mutate or extend properties on the `window` object.
+
+By default, it will include scripts matching `/\.([cem]?js|ts)$/`, but you can provide custom filter options in the call to `webExtension(options?: ViteWebExtensionOptions)`:
+
+```ts
+type Pattern = string | RegExp | Array<string | RegExp>;
+
+interface ViteWebExtensionOptions {
+  manifest: chrome.runtime.Manifest;
+
+  webAccessibleScripts?: {
+    include?: Pattern;
+    exclude?: Pattern;
+    options?: {
+      resolve?: string | false | null;
+    };
+  };
+}
+```
+
 #### TypeScript
 
 In an [env.d.ts file](https://vitejs.dev/guide/env-and-mode.html#intellisense-for-typescript), add the following type reference to define the plugin specific `import.meta` variables as well as plugin client functions:

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "homepage": "https://github.com/samrum/vite-plugin-web-extension#readme",
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.2.5",
+    "@rollup/pluginutils": "^4.2.1",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.0.1",
     "@types/node": "^16.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,8 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@rollup/plugin-typescript': ^8.2.5
+  '@rollup/pluginutils': ^4.2.1
   '@types/chrome': ^0.0.174
   '@types/etag': ^1.8.1
   '@types/fs-extra': ^9.0.13
@@ -30,7 +31,8 @@ dependencies:
   vite: 2.9.0
 
 devDependencies:
-  '@rollup/plugin-typescript': 8.2.5_d671d3387afbf1a138cd7f3f4762053b
+  '@rollup/plugin-typescript': 8.2.5_2zy5god27py2cognp47uoyqfhm
+  '@rollup/pluginutils': 4.2.1
   '@types/fs-extra': 9.0.13
   '@types/jest': 27.0.1
   '@types/node': 16.9.1
@@ -40,7 +42,7 @@ devDependencies:
   prettier: 2.4.1
   rollup: 2.56.3
   standard-version: 9.3.1
-  ts-jest: 27.0.5_77a678c07bcdbdfd88181ff63fe325b2
+  ts-jest: 27.0.5_o6thrqd3zw673cayd73d7yzfwi
   tslib: 2.3.1
   typescript: 4.4.3
 
@@ -228,6 +230,8 @@ packages:
     resolution: {integrity: sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.15.6
     dev: true
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.15.5:
@@ -599,7 +603,7 @@ packages:
       chalk: 4.1.2
     dev: true
 
-  /@rollup/plugin-typescript/8.2.5_d671d3387afbf1a138cd7f3f4762053b:
+  /@rollup/plugin-typescript/8.2.5_2zy5god27py2cognp47uoyqfhm:
     resolution: {integrity: sha512-QL/LvDol/PAGB2O0S7/+q2HpSUNodpw7z6nGn9BfoVCPOZ0r4EALrojFU29Bkoi2Hr2jgTocTejJ5GGWZfOxbQ==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -624,6 +628,14 @@ packages:
       estree-walker: 1.0.1
       picomatch: 2.3.0
       rollup: 2.56.3
+    dev: true
+
+  /@rollup/pluginutils/4.2.1:
+    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
+    engines: {node: '>= 8.0.0'}
+    dependencies:
+      estree-walker: 2.0.2
+      picomatch: 2.3.0
     dev: true
 
   /@sinonjs/commons/1.8.3:
@@ -1760,6 +1772,10 @@ packages:
 
   /estree-walker/1.0.1:
     resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
+    dev: true
+
+  /estree-walker/2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
     dev: true
 
   /esutils/2.0.3:
@@ -3926,7 +3942,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ts-jest/27.0.5_77a678c07bcdbdfd88181ff63fe325b2:
+  /ts-jest/27.0.5_o6thrqd3zw673cayd73d7yzfwi:
     resolution: {integrity: sha512-lIJApzfTaSSbtlksfFNHkWOzLJuuSm4faFAfo5kvzOiRAuoN4/eKxVJ2zEAho8aecE04qX6K1pAzfH5QHL1/8w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true

--- a/src/devBuilder/devBuilder.ts
+++ b/src/devBuilder/devBuilder.ts
@@ -4,6 +4,7 @@ import { ResolvedConfig, ViteDevServer, normalizePath } from "vite";
 import { getContentScriptLoaderFile } from "../utils/loader";
 import { getInputFileName, getOutputFileName } from "../utils/file";
 import { getVirtualModule } from "../utils/virtualModule";
+import { PluginExtras } from "..";
 
 export default abstract class DevBuilder<
   Manifest extends chrome.runtime.Manifest
@@ -14,6 +15,7 @@ export default abstract class DevBuilder<
 
   constructor(
     private viteConfig: ResolvedConfig,
+    private pluginExtras: PluginExtras,
     private viteDevServer?: ViteDevServer
   ) {
     this.outDir = this.viteConfig.build.outDir;
@@ -35,6 +37,10 @@ export default abstract class DevBuilder<
 
     await this.writeManifestHtmlFiles(manifestHtmlFiles);
     await this.writeManifestContentScriptFiles(manifest);
+    await this.writeManifestWebAccessibleScriptFiles(
+      manifest,
+      this.pluginExtras.webAccessibleScriptsFilter
+    );
 
     await this.writeBuildFiles(manifest, manifestHtmlFiles);
 
@@ -166,6 +172,11 @@ export default abstract class DevBuilder<
       }
     }
   }
+
+  protected abstract writeManifestWebAccessibleScriptFiles(
+    manifest: Manifest,
+    webAccessibleScriptsFilter: PluginExtras["webAccessibleScriptsFilter"]
+  ): Promise<void>;
 
   private getHmrServerOrigin(devServerPort: number): string {
     if (typeof this.viteConfig.server.hmr! === "boolean") {

--- a/src/devBuilder/devBuilderManifestV2.ts
+++ b/src/devBuilder/devBuilderManifestV2.ts
@@ -1,4 +1,9 @@
 import crypto from "crypto";
+import { ensureDir, writeFile } from "fs-extra";
+import path from "path";
+import { PluginExtras } from "..";
+import { getOutputFileName } from "../utils/file";
+import { getContentScriptLoaderFile } from "../utils/loader";
 import DevBuilder from "./devBuilder";
 
 export default class DevBuilderManifestV2 extends DevBuilder<chrome.runtime.ManifestV2> {
@@ -20,6 +25,44 @@ export default class DevBuilderManifestV2 extends DevBuilder<chrome.runtime.Mani
       shasum.update(match[1]);
 
       this.inlineScriptHashes.add(`'sha256-${shasum.digest("base64")}'`);
+    }
+  }
+
+  protected async writeManifestWebAccessibleScriptFiles(
+    manifest: chrome.runtime.ManifestV2,
+    webAccessibleScriptsFilter: PluginExtras["webAccessibleScriptsFilter"]
+  ) {
+    if (!manifest.web_accessible_resources) {
+      return;
+    }
+
+    for (const [
+      webAccessibleResourceIndex,
+      resourceFileName,
+    ] of manifest.web_accessible_resources.entries()) {
+      if (!resourceFileName) {
+        continue;
+      }
+
+      if (!webAccessibleScriptsFilter(resourceFileName)) continue;
+
+      const outputFileName = getOutputFileName(resourceFileName);
+
+      const scriptLoaderFile = getContentScriptLoaderFile(
+        outputFileName,
+        `${this.hmrServerOrigin}/${resourceFileName}`
+      );
+
+      manifest.web_accessible_resources[webAccessibleResourceIndex] =
+        scriptLoaderFile.fileName;
+
+      const outFile = `${this.outDir}/${scriptLoaderFile.fileName}`;
+
+      const outFileDir = path.dirname(outFile);
+
+      await ensureDir(outFileDir);
+
+      await writeFile(outFile, scriptLoaderFile.source);
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,11 @@ import {
   transformSelfLocationAssets,
   updateConfigForExtensionSupport,
 } from "./utils/vite";
+import { createFilter } from "@rollup/pluginutils";
+
+export interface PluginExtras {
+  webAccessibleScriptsFilter: ReturnType<typeof createFilter>;
+}
 
 export default function webExtension(
   pluginOptions: ViteWebExtensionOptions
@@ -23,6 +28,13 @@ export default function webExtension(
   let manifestParser:
     | ManifestParser<chrome.runtime.ManifestV2>
     | ManifestParser<chrome.runtime.ManifestV3>;
+
+  const webConfig = pluginOptions.webAccessibleScripts;
+  let webAccessibleScriptsFilter = createFilter(
+    webConfig?.include || /\.([cem]?js|ts)$/,
+    webConfig?.exclude || "",
+    webConfig?.options
+  );
 
   return {
     name: "webExtension",
@@ -48,6 +60,7 @@ export default function webExtension(
     async options(options) {
       manifestParser = ManifestParserFactory.getParser(
         JSON.parse(JSON.stringify(pluginOptions.manifest)),
+        { webAccessibleScriptsFilter },
         viteConfig
       );
 

--- a/src/manifestParser/manifestParser.ts
+++ b/src/manifestParser/manifestParser.ts
@@ -5,6 +5,7 @@ import { getInputFileName, getOutputFileName } from "../utils/file";
 import type { EmittedFile, OutputBundle } from "rollup";
 import { getContentScriptLoaderForOutputChunk } from "../utils/loader";
 import { getChunkInfoFromBundle } from "../utils/rollup";
+import { PluginExtras } from "..";
 
 export interface ParseResult<Manifest extends chrome.runtime.Manifest> {
   inputScripts: [string, string][];
@@ -19,6 +20,7 @@ export default abstract class ManifestParser<
 
   constructor(
     protected inputManifest: Manifest,
+    protected pluginExtras: PluginExtras,
     protected viteConfig: ResolvedConfig
   ) {}
 
@@ -33,6 +35,7 @@ export default abstract class ManifestParser<
       parseResult,
       this.parseInputHtmlFiles,
       this.parseInputContentScripts,
+      this.parseInputWebAccessibleScripts,
       ...this.getParseInputMethods()
     );
   }
@@ -119,6 +122,10 @@ export default abstract class ManifestParser<
 
     return result;
   }
+
+  protected abstract parseInputWebAccessibleScripts(
+    result: ParseResult<Manifest>
+  ): ParseResult<Manifest>;
 
   protected parseInputHtmlFile(
     htmlFileName: string | undefined,

--- a/src/manifestParser/manifestParserFactory.ts
+++ b/src/manifestParser/manifestParserFactory.ts
@@ -1,4 +1,5 @@
 import { ResolvedConfig } from "vite";
+import { PluginExtras } from "..";
 import ManifestParser from "./manifestParser";
 import ManifestV2 from "./manifestV2";
 import ManifestV3 from "./manifestV3";
@@ -6,15 +7,16 @@ import ManifestV3 from "./manifestV3";
 export default class ManifestParserFactory {
   static getParser(
     manifest: chrome.runtime.Manifest,
+    pluginExtras: PluginExtras,
     viteConfig: ResolvedConfig
   ):
     | ManifestParser<chrome.runtime.ManifestV2>
     | ManifestParser<chrome.runtime.ManifestV3> {
     switch (manifest.manifest_version) {
       case 2:
-        return new ManifestV2(manifest, viteConfig);
+        return new ManifestV2(manifest, pluginExtras, viteConfig);
       case 3:
-        return new ManifestV3(manifest, viteConfig);
+        return new ManifestV3(manifest, pluginExtras, viteConfig);
       default:
         throw new Error(
           `No parser available for manifest_version ${

--- a/src/manifestParser/manifestV2.ts
+++ b/src/manifestParser/manifestV2.ts
@@ -16,7 +16,11 @@ type ManifestParseResult = ParseResult<Manifest>;
 
 export default class ManifestV2 extends ManifestParser<Manifest> {
   protected createDevBuilder(): DevBuilder<Manifest> {
-    return new DevBuilderManifestV2(this.viteConfig, this.viteDevServer);
+    return new DevBuilderManifestV2(
+      this.viteConfig,
+      this.pluginExtras,
+      this.viteDevServer
+    );
   }
 
   protected getHtmlFileNames(manifest: Manifest): string[] {

--- a/src/manifestParser/manifestV3.ts
+++ b/src/manifestParser/manifestV3.ts
@@ -78,11 +78,15 @@ export default class ManifestV3 extends ManifestParser<Manifest> {
     result: ParseResult<Manifest>
   ): ParseResult<Manifest> {
     result.manifest.web_accessible_resources?.forEach((struct) => {
-      struct.resources.forEach((scriptFile) => {
-        const inputFile = getInputFileName(scriptFile, this.viteConfig.root);
-        const outputFile = getOutputFileName(scriptFile);
+      struct.resources.forEach((resource) => {
+        if (resource.includes("*")) return;
 
-        result.inputScripts.push([outputFile, inputFile]);
+        const inputFile = getInputFileName(resource, this.viteConfig.root);
+        const outputFile = getOutputFileName(resource);
+
+        if (this.pluginExtras.webAccessibleScriptsFilter(inputFile)) {
+          result.inputScripts.push([outputFile, inputFile]);
+        }
       });
     });
 

--- a/src/manifestParser/manifestV3.ts
+++ b/src/manifestParser/manifestV3.ts
@@ -16,7 +16,11 @@ type ManifestParseResult = ParseResult<Manifest>;
 
 export default class ManifestV3 extends ManifestParser<Manifest> {
   protected createDevBuilder(): DevBuilder<Manifest> {
-    return new DevBuilderManifestV3(this.viteConfig, this.viteDevServer);
+    return new DevBuilderManifestV3(
+      this.viteConfig,
+      this.pluginExtras,
+      this.viteDevServer
+    );
   }
 
   protected getHtmlFileNames(manifest: Manifest): string[] {

--- a/test/fixture/index/javascript/manifestV2/index.ts
+++ b/test/fixture/index/javascript/manifestV2/index.ts
@@ -10,4 +10,5 @@ export { default as ContentWithSameScriptName } from "./contentWithSameScriptNam
 export { default as OptionsHtml } from "./optionsHtml";
 export { default as PopupHtml } from "./popupHtml";
 export { default as WebAccessibleResourceHtml } from "./webAccessibleResourceHtml";
+export { default as WebAccessibleScript } from "./webAccessibleScript";
 export { default as ContentScriptPaths } from "./contentScriptPaths";

--- a/test/fixture/index/javascript/manifestV2/webAccessibleScript.ts
+++ b/test/fixture/index/javascript/manifestV2/webAccessibleScript.ts
@@ -9,7 +9,7 @@ const inputManifest = {
 };
 
 const expectedManifest = {
-  web_accessible_resources: [`${resourceDir}/webAccessibleScript.js`],
+  web_accessible_resources: [`assets/${resourceDir}/webAccessibleScript.js`],
 };
 
 export default {

--- a/test/fixture/index/javascript/manifestV2/webAccessibleScript.ts
+++ b/test/fixture/index/javascript/manifestV2/webAccessibleScript.ts
@@ -1,0 +1,19 @@
+import { getExpectedHtml, getExpectedLog } from "../../../fixtureUtils";
+import { getExpectedCode } from "../shared/webAccessibleScript";
+
+const resourceDir =
+  "test/fixture/index/javascript/resources/webAccessibleScript";
+
+const inputManifest = {
+  web_accessible_resources: [`${resourceDir}/webAccessibleScript.js`],
+};
+
+const expectedManifest = {
+  web_accessible_resources: [`${resourceDir}/webAccessibleScript.js`],
+};
+
+export default {
+  inputManifest,
+  expectedManifest,
+  ...getExpectedCode(resourceDir),
+};

--- a/test/fixture/index/javascript/manifestV3/index.ts
+++ b/test/fixture/index/javascript/manifestV3/index.ts
@@ -10,3 +10,4 @@ export { default as ContentWithNoImports } from "./contentWithNoImports";
 export { default as OptionsHtml } from "./optionsHtml";
 export { default as PopupHtml } from "./popupHtml";
 export { default as WebAccessibleResourceHtml } from "./webAccessibleResourceHtml";
+export { default as WebAccessibleScript } from "./webAccessibleScript";

--- a/test/fixture/index/javascript/manifestV3/webAccessibleScript.ts
+++ b/test/fixture/index/javascript/manifestV3/webAccessibleScript.ts
@@ -1,7 +1,7 @@
 import { getExpectedCode } from "../shared/webAccessibleScript";
 
 const resourceDir =
-  "test/fixture/index/javascript/resources/webAccessibleSciprt";
+  "test/fixture/index/javascript/resources/webAccessibleScript";
 
 const inputManifest = {
   web_accessible_resources: [
@@ -15,7 +15,7 @@ const inputManifest = {
 const expectedManifest = {
   web_accessible_resources: [
     {
-      resources: [`${resourceDir}/webAccessibleScript.js`],
+      resources: [`assets/${resourceDir}/webAccessibleScript.js`],
       matches: ["https://*/*", "http://*/*"],
     },
   ],

--- a/test/fixture/index/javascript/manifestV3/webAccessibleScript.ts
+++ b/test/fixture/index/javascript/manifestV3/webAccessibleScript.ts
@@ -1,0 +1,28 @@
+import { getExpectedCode } from "../shared/webAccessibleScript";
+
+const resourceDir =
+  "test/fixture/index/javascript/resources/webAccessibleSciprt";
+
+const inputManifest = {
+  web_accessible_resources: [
+    {
+      resources: [`${resourceDir}/webAccessibleScript.js`],
+      matches: ["https://*/*", "http://*/*"],
+    },
+  ],
+};
+
+const expectedManifest = {
+  web_accessible_resources: [
+    {
+      resources: [`${resourceDir}/webAccessibleScript.js`],
+      matches: ["https://*/*", "http://*/*"],
+    },
+  ],
+};
+
+export default {
+  inputManifest,
+  expectedManifest,
+  ...getExpectedCode(resourceDir),
+};

--- a/test/fixture/index/javascript/resources/webAccessibleScript/webAccessibleScript.js
+++ b/test/fixture/index/javascript/resources/webAccessibleScript/webAccessibleScript.js
@@ -1,0 +1,3 @@
+import log from "../shared/log";
+
+log("webAccessibleScript");

--- a/test/fixture/index/javascript/shared/webAccessibleScript.ts
+++ b/test/fixture/index/javascript/shared/webAccessibleScript.ts
@@ -1,0 +1,16 @@
+import { getExpectedHtml, getExpectedLog } from "../../../fixtureUtils";
+
+export function getExpectedCode(resourceDir: string) {
+  const chunkCode = {
+    [`assets/${resourceDir}/webAccessibleScript.js`]: getExpectedLog(
+      "webAccessibleScript"
+    ),
+  };
+
+  const assetCode = {};
+
+  return {
+    chunkCode,
+    assetCode,
+  };
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,10 +1,24 @@
 import type { Plugin, ChunkMetadata } from "vite";
 
+type Pattern = string | RegExp | Array<string | RegExp>;
+
 interface ViteWebExtensionOptions {
   /**
    * The manifest file to use as a base for the generated extension
    */
   manifest: chrome.runtime.Manifest;
+
+  /**
+   * Options for compiling web accessible scripts
+   * <https://github.com/rollup/plugins/tree/master/packages/pluginutils#createfilter>
+   */
+  webAccessibleScripts?: {
+    include?: Pattern;
+    exclude?: Pattern;
+    options?: {
+      resolve?: string | false | null;
+    };
+  };
 }
 
 /**


### PR DESCRIPTION
Adds ability to transpile scripts that user includes as web accessible resources. For instance, if a content script needs to inject an _inpage_ script into the webpage at runtime, the user can simply include the path to the inpage script as a `web_accessible_resource` and the plugin will take care of the rest.

This PR also adds a new plugin option `webAccessibleScripts` that simply mirrors the inputs to [`createFilter`](https://github.com/rollup/plugins/tree/master/packages/pluginutils#createfilter), allowing user to control which files will match as scripts:
```ts
interface ViteWebExtensionOptions {
  webAccessibleScripts?: {
    include?: Pattern;
    exclude?: Pattern;
    options?: {
      resolve?: string | false | null;
    };
  };
}
```