### PR TITLE
chore: bump Vite to 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "dist/index.es.js",
   "types": "types/index.d.ts",
   "engines": {
-    "node": ">=12.0.0"
+    "node": "^14.18.0 || >=16.0.0"
   },
   "packageManager": "pnpm@7.6.0",
   "files": [
@@ -68,7 +68,7 @@
     "vitest": "^0.18.1"
   },
   "peerDependencies": {
-    "vite": "^2.9.0"
+    "vite": "^3.0.2"
   },
   "lint-staged": {
     "*.{js,ts,css,md}": "prettier --write"
@@ -79,6 +79,6 @@
     "etag": "^1.8.1",
     "fs-extra": "^10.0.0",
     "magic-string": "^0.25.7",
-    "vite": "~2.9.0"
+    "vite": "~3.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ specifiers:
   standard-version: ^9.5.0
   tslib: ^2.4.0
   typescript: ^4.7.4
-  vite: ~2.9.0
+  vite: ~3.0.2
   vitest: ^0.18.1
 
 dependencies:
@@ -26,7 +26,7 @@ dependencies:
   etag: 1.8.1
   fs-extra: 10.0.0
   magic-string: 0.25.7
-  vite: 2.9.14
+  vite: 3.0.2
 
 devDependencies:
   '@rollup/plugin-typescript': 8.2.5_25ya7mrrsrxjsticp2bpsu7cge
@@ -2047,30 +2047,6 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite/2.9.14:
-    resolution: {integrity: sha512-P/UCjSpSMcE54r4mPak55hWAZPlyfS369svib/gpmz8/01L822lMPOJ/RYW6tLCe1RPvMvOsJ17erf55bKp4Hw==}
-    engines: {node: '>=12.2.0'}
-    hasBin: true
-    peerDependencies:
-      less: '*'
-      sass: '*'
-      stylus: '*'
-    peerDependenciesMeta:
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-    dependencies:
-      esbuild: 0.14.49
-      postcss: 8.4.14
-      resolve: 1.22.1
-      rollup: 2.77.0
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: false
-
   /vite/3.0.2:
     resolution: {integrity: sha512-TAqydxW/w0U5AoL5AsD9DApTvGb2iNbGs3sN4u2VdT1GFkQVUfgUldt+t08TZgi23uIauh1TUOQJALduo9GXqw==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -2096,7 +2072,6 @@ packages:
       rollup: 2.77.0
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /vitest/0.18.1:
     resolution: {integrity: sha512-4F/1K/Vn4AvJwe7i2YblR02PT5vMKcw9KN4unDq2KD0YcSxX0B/6D6Qu9PJaXwVuxXMFTQ5ovd4+CQaW3bwofA==}

--- a/test/fixture/fixtureUtils.ts
+++ b/test/fixture/fixtureUtils.ts
@@ -33,7 +33,9 @@ export function getExpectedLogChunk(): string {
   return `function log(message) {
   console.log(message);
 }
-export { log as l };
+export {
+  log as l
+};
 `;
 }
 
@@ -47,7 +49,9 @@ export function getExpectedLogDynamicChunk(): string {
   return `function log(message) {
   console.log(message);
 }
-export { log as default };
+export {
+  log as default
+};
 `;
 }
 

--- a/test/fixture/index/javascript/manifestV2/chunkCssRewrite.ts
+++ b/test/fixture/index/javascript/manifestV2/chunkCssRewrite.ts
@@ -35,9 +35,9 @@ const expectedManifest = {
     },
   ],
   web_accessible_resources: [
-    `assets/${resourceDir}/content1.css`,
+    `assets/content1.css`,
     `assets/contentShared.css`,
-    `assets/${resourceDir}/content2.css`,
+    `assets/content2.css`,
   ],
 };
 

--- a/test/fixture/index/javascript/shared/chunkCssRewrite.ts
+++ b/test/fixture/index/javascript/shared/chunkCssRewrite.ts
@@ -2,19 +2,19 @@ import { getExpectedCss } from "../../../fixtureUtils";
 
 export function getExpectedCode(resourceDir: string) {
   const chunkCode = {
-    [`assets/${resourceDir}/content1.js`]: `/* empty css                               */var content1 = "";
-console.log(["assets/test/fixture/index/javascript/resources/chunkCssRewrite/content1.css","assets/contentShared.css"]);
+    [`assets/${resourceDir}/content1.js`]: `/* empty css                               */const content1 = "";
+console.log(["assets/content1.css","assets/contentShared.css"]);
 `,
-    [`assets/${resourceDir}/content2.js`]: `/* empty css                               */var content2 = "";
-console.log(["assets/test/fixture/index/javascript/resources/chunkCssRewrite/content2.css","assets/contentShared.css"]);
+    [`assets/${resourceDir}/content2.js`]: `/* empty css                               */const content2 = "";
+console.log(["assets/content2.css","assets/contentShared.css"]);
 `,
     [`assets/${resourceDir}/contentNoCss.js`]: `console.log([]);
 `,
   };
 
   const assetCode = {
-    [`assets/${resourceDir}/content1.css`]: getExpectedCss("content1"),
-    [`assets/${resourceDir}/content2.css`]: getExpectedCss("content2"),
+    [`assets/content1.css`]: getExpectedCss("content1"),
+    [`assets/content2.css`]: getExpectedCss("content2"),
     [`assets/contentShared.css`]: getExpectedCss("contentShared"),
   };
 


### PR DESCRIPTION
BREAKING CHANGE: Vite 3 is the minimum supported version of Vite
