### PR TITLE
fix: make dynamic imports resolve relative to extension host

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,13 @@ export default function webExtension(
       emitQueue = [];
     },
 
+    renderDynamicImport() {
+      return {
+        left: "import((chrome != null ? chrome : browser).runtime.getURL(",
+        right: "))",
+      };
+    },
+
     resolveId(id) {
       const module = getVirtualModule(id);
 

--- a/test/fixture/fixtureUtils.ts
+++ b/test/fixture/fixtureUtils.ts
@@ -58,7 +58,7 @@ export {
 export function getExpectedLogFromDynamicChunk(message: string): string {
   return `import { _ as __vitePreload } from "../../../../../../preload-helper.js";
 (async () => {
-  const log = await __vitePreload(() => import("../../../../../../log.js"), true ? [] : void 0);
+  const log = await __vitePreload(() => import((chrome != null ? chrome : browser).runtime.getURL("../../../../../../log.js")), true ? [] : void 0);
   log("${message}");
 })();
 `;

--- a/test/fixture/index/javascript/manifestV2/contentWithDynamicImport.ts
+++ b/test/fixture/index/javascript/manifestV2/contentWithDynamicImport.ts
@@ -1,9 +1,3 @@
-import {
-  getExpectedContentLoaderHtml,
-  getExpectedLogDynamicChunk,
-  getExpectedLogFromDynamicChunk,
-  getPreloadHelper,
-} from "../../../fixtureUtils";
 import { getExpectedCode } from "../shared/contentWithDynamicImport";
 
 const resourceDir =

--- a/test/fixture/index/javascript/manifestV3/contentWithDynamicImport.ts
+++ b/test/fixture/index/javascript/manifestV3/contentWithDynamicImport.ts
@@ -1,9 +1,3 @@
-import {
-  getExpectedContentLoaderHtml,
-  getExpectedLogDynamicChunk,
-  getExpectedLogFromDynamicChunk,
-  getPreloadHelper,
-} from "../../../fixtureUtils";
 import { getExpectedCode } from "../shared/contentWithDynamicImport";
 
 const resourceDir =


### PR DESCRIPTION
wraps dynamic imports paths with runtime.getURL to fix dynamic imports made from content scripts
