### PR TITLE
Include Imports from Web Accessible Scripts in Manifest v3

### DIFF
--- a/src/manifestParser/manifestV3.ts
+++ b/src/manifestParser/manifestV3.ts
@@ -143,6 +143,7 @@ export default class ManifestV3 extends ManifestParser<Manifest> {
             ];
           }
 
+          // include non-script resources as-is
           return resourceFileName;
         }
       );

--- a/src/manifestParser/manifestV3.ts
+++ b/src/manifestParser/manifestV3.ts
@@ -127,17 +127,28 @@ export default class ManifestV3 extends ManifestParser<Manifest> {
     });
 
     (result.manifest.web_accessible_resources ?? []).forEach((struct) => {
-      struct.resources.forEach((resourceFileName, index) => {
-        if (this.pluginExtras.webAccessibleScriptsFilter(resourceFileName)) {
-          const parsedWebAccessibleScript = this.parseOutputContentScript(
-            resourceFileName,
-            result,
-            bundle
-          );
+      const flattenedResources: string[] = struct.resources.flatMap(
+        (resourceFileName) => {
+          if (this.pluginExtras.webAccessibleScriptsFilter(resourceFileName)) {
+            const parsedWebAccessibleScript = this.parseOutputContentScript(
+              resourceFileName,
+              result,
+              bundle
+            );
 
-          struct.resources[index] = parsedWebAccessibleScript.scriptFileName;
+            // merge `scriptFileName` along with the set of resources the script imports
+            return [
+              parsedWebAccessibleScript.scriptFileName,
+              ...parsedWebAccessibleScript.webAccessibleFiles,
+            ];
+          }
+
+          return resourceFileName;
         }
-      });
+      );
+
+      // removes any duplicates from the flattened resources
+      struct.resources = Array.from(new Set(flattenedResources));
 
       webAccessibleResources.add(struct);
     });


### PR DESCRIPTION
This fix ensures that imported resources from web accessible scripts are included as web accessible resources in the output manifest. The `manifestV2.ts` parser is already doing this the correct way.

To keep the code simple and readable, this approach uses flatMap to replace the `struct.resources` array. This is why `resourceFileName` is returned if the resource is not a script (otherwise non-script resources would be omitted from the output manifest).