### PR TITLE
fix(manifest V3): correct matches property in web accessible resources

### DIFF
--- a/src/manifestParser/manifestV3.ts
+++ b/src/manifestParser/manifestV3.ts
@@ -1,3 +1,5 @@
+import { OutputBundle } from "rollup";
+import { URL } from "url";
 import { ParseResult } from "./manifestParser";
 import {
   isSingleHtmlFilename,
@@ -8,7 +10,6 @@ import ManifestParser from "./manifestParser";
 import DevBuilder from "../devBuilder/devBuilder";
 import { getServiceWorkerLoaderFile } from "../utils/loader";
 import DevBuilderManifestV3 from "../devBuilder/devBuilderManifestV3";
-import { OutputBundle } from "rollup";
 import { getChunkInfoFromBundle } from "../utils/rollup";
 
 type Manifest = chrome.runtime.ManifestV3;
@@ -121,7 +122,15 @@ export default class ManifestV3 extends ManifestParser<Manifest> {
         if (parsedContentScript.webAccessibleFiles.size) {
           webAccessibleResources.add({
             resources: Array.from(parsedContentScript.webAccessibleFiles),
-            matches: script.matches!,
+            matches: script.matches!.map((matchPattern) => {
+              const url = new URL(matchPattern);
+
+              if (url.pathname === "/") {
+                return `${url}`;
+              }
+
+              return `${url.origin}/*`;
+            }),
             // @ts-ignore - use_dynamic_url is a newly supported option
             use_dynamic_url: true,
           });

--- a/test/fixture/index/javascript/manifestV3/contentWithChunkedImport.ts
+++ b/test/fixture/index/javascript/manifestV3/contentWithChunkedImport.ts
@@ -1,8 +1,3 @@
-import {
-  getExpectedContentLoaderHtml,
-  getExpectedLogChunk,
-  getExpectedLogFromChunk,
-} from "../../../fixtureUtils";
 import { getExpectedCode } from "../shared/contentWithChunkedImport";
 
 const resourceDir =
@@ -12,11 +7,11 @@ const inputManifest = {
   content_scripts: [
     {
       js: [`${resourceDir}/content1.js`],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
     },
     {
       js: [`${resourceDir}/content2.js`],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
     },
   ],
 };
@@ -25,22 +20,22 @@ const expectedManifest = {
   content_scripts: [
     {
       js: [`${resourceDir}/content1.js`],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
     },
     {
       js: [`${resourceDir}/content2.js`],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
     },
   ],
   web_accessible_resources: [
     {
       resources: [`assets/${resourceDir}/content1.js`, "assets/log.js"],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/*"],
       use_dynamic_url: true,
     },
     {
       resources: [`assets/${resourceDir}/content2.js`, "assets/log.js"],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/*"],
       use_dynamic_url: true,
     },
   ],

--- a/test/fixture/index/javascript/manifestV3/contentWithDynamicImport.ts
+++ b/test/fixture/index/javascript/manifestV3/contentWithDynamicImport.ts
@@ -7,11 +7,11 @@ const inputManifest = {
   content_scripts: [
     {
       js: [`${resourceDir}/content1.js`],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
     },
     {
       js: [`${resourceDir}/content2.js`],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
     },
   ],
 };
@@ -20,11 +20,11 @@ const expectedManifest = {
   content_scripts: [
     {
       js: [`${resourceDir}/content1.js`],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
     },
     {
       js: [`${resourceDir}/content2.js`],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
     },
   ],
   web_accessible_resources: [
@@ -34,7 +34,7 @@ const expectedManifest = {
         "assets/preload-helper.js",
         "assets/log.js",
       ],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/*"],
       use_dynamic_url: true,
     },
     {
@@ -43,7 +43,7 @@ const expectedManifest = {
         "assets/preload-helper.js",
         "assets/log.js",
       ],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/*"],
       use_dynamic_url: true,
     },
   ],

--- a/test/fixture/index/javascript/manifestV3/contentWithNoImports.ts
+++ b/test/fixture/index/javascript/manifestV3/contentWithNoImports.ts
@@ -7,7 +7,7 @@ const inputManifest = {
   content_scripts: [
     {
       js: [`${resourceDir}/content.js`],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
     },
   ],
 };
@@ -16,7 +16,7 @@ const expectedManifest = {
   content_scripts: [
     {
       js: [`assets/${resourceDir}/content.js`],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
     },
   ],
 };

--- a/test/fixture/index/javascript/manifestV3/contentWithSameScriptName.ts
+++ b/test/fixture/index/javascript/manifestV3/contentWithSameScriptName.ts
@@ -7,11 +7,11 @@ const inputManifest = {
   content_scripts: [
     {
       js: [`${resourceDir}/content1/content.js`],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
     },
     {
       js: [`${resourceDir}/content2/content.js`],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
     },
   ],
 };
@@ -20,11 +20,11 @@ const expectedManifest = {
   content_scripts: [
     {
       js: [`assets/${resourceDir}/content1/content.js`],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
     },
     {
       js: [`assets/${resourceDir}/content2/content.js`],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
     },
   ],
 };

--- a/test/fixture/index/javascript/manifestV3/contentWithUnchunkedImport.ts
+++ b/test/fixture/index/javascript/manifestV3/contentWithUnchunkedImport.ts
@@ -8,7 +8,7 @@ const inputManifest = {
   content_scripts: [
     {
       js: [`${resourceDir}/content.js`],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
     },
   ],
 };
@@ -17,7 +17,7 @@ const expectedManifest = {
   content_scripts: [
     {
       js: [`assets/${resourceDir}/content.js`],
-      matches: ["https://*/*", "http://*/*"],
+      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
     },
   ],
 };


### PR DESCRIPTION
Chrome will throw an error when loading an extension that contains a web accessible resource with a matches property that contains a path. This PR ensures that content script match patterns used for their web accessible resources are trimmed to their origin instead of being passed through completely.