### PR TITLE
fix(manifest v3): web accessible resource match rewrite is broken

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import typescript from "@rollup/plugin-typescript";
 
 import pkg from "./package.json";
 
-const external = ["path", "fs", "crypto", "url"].concat(
+const external = ["path", "fs", "crypto"].concat(
   Object.keys(pkg.dependencies ?? {})
 );
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import typescript from "@rollup/plugin-typescript";
 
 import pkg from "./package.json";
 
-const external = ["path", "fs", "crypto"].concat(
+const external = ["path", "fs", "crypto", "url"].concat(
   Object.keys(pkg.dependencies ?? {})
 );
 

--- a/src/manifestParser/manifestV3.ts
+++ b/src/manifestParser/manifestV3.ts
@@ -1,5 +1,4 @@
 import { OutputBundle } from "rollup";
-import { URL } from "url";
 import { ParseResult } from "./manifestParser";
 import {
   isSingleHtmlFilename,

--- a/src/manifestParser/manifestV3.ts
+++ b/src/manifestParser/manifestV3.ts
@@ -123,13 +123,17 @@ export default class ManifestV3 extends ManifestParser<Manifest> {
           webAccessibleResources.add({
             resources: Array.from(parsedContentScript.webAccessibleFiles),
             matches: script.matches!.map((matchPattern) => {
-              const url = new URL(matchPattern);
-
-              if (url.pathname === "/") {
-                return `${url}`;
+              const pathMatch = /[^:\/]\//.exec(matchPattern);
+              if (!pathMatch) {
+                return matchPattern;
               }
 
-              return `${url.origin}/*`;
+              const path = matchPattern.slice(pathMatch.index + 1);
+              if (["/", "/*"].includes(path)) {
+                return matchPattern;
+              }
+
+              return matchPattern.replace(path, "/*");
             }),
             // @ts-ignore - use_dynamic_url is a newly supported option
             use_dynamic_url: true,

--- a/test/fixture/index/javascript/manifestV3/contentWithChunkedImport.ts
+++ b/test/fixture/index/javascript/manifestV3/contentWithChunkedImport.ts
@@ -7,11 +7,25 @@ const inputManifest = {
   content_scripts: [
     {
       js: [`${resourceDir}/content1.js`],
-      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/subpath/*",
+        "https://example.com/subpath/*",
+      ],
     },
     {
       js: [`${resourceDir}/content2.js`],
-      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/subpath/*",
+        "https://example.com/subpath/*",
+      ],
     },
   ],
 };
@@ -20,22 +34,50 @@ const expectedManifest = {
   content_scripts: [
     {
       js: [`${resourceDir}/content1.js`],
-      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/subpath/*",
+        "https://example.com/subpath/*",
+      ],
     },
     {
       js: [`${resourceDir}/content2.js`],
-      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/subpath/*",
+        "https://example.com/subpath/*",
+      ],
     },
   ],
   web_accessible_resources: [
     {
       resources: [`assets/${resourceDir}/content1.js`, "assets/log.js"],
-      matches: ["https://*/*", "http://*/*", "http://example.com/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/*",
+        "https://example.com/*",
+      ],
       use_dynamic_url: true,
     },
     {
       resources: [`assets/${resourceDir}/content2.js`, "assets/log.js"],
-      matches: ["https://*/*", "http://*/*", "http://example.com/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/*",
+        "https://example.com/*",
+      ],
       use_dynamic_url: true,
     },
   ],

--- a/test/fixture/index/javascript/manifestV3/contentWithDynamicImport.ts
+++ b/test/fixture/index/javascript/manifestV3/contentWithDynamicImport.ts
@@ -7,11 +7,25 @@ const inputManifest = {
   content_scripts: [
     {
       js: [`${resourceDir}/content1.js`],
-      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/subpath/*",
+        "https://example.com/subpath/*",
+      ],
     },
     {
       js: [`${resourceDir}/content2.js`],
-      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/subpath/*",
+        "https://example.com/subpath/*",
+      ],
     },
   ],
 };
@@ -20,11 +34,25 @@ const expectedManifest = {
   content_scripts: [
     {
       js: [`${resourceDir}/content1.js`],
-      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/subpath/*",
+        "https://example.com/subpath/*",
+      ],
     },
     {
       js: [`${resourceDir}/content2.js`],
-      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/subpath/*",
+        "https://example.com/subpath/*",
+      ],
     },
   ],
   web_accessible_resources: [
@@ -34,7 +62,14 @@ const expectedManifest = {
         "assets/preload-helper.js",
         "assets/log.js",
       ],
-      matches: ["https://*/*", "http://*/*", "http://example.com/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/*",
+        "https://example.com/*",
+      ],
       use_dynamic_url: true,
     },
     {
@@ -43,7 +78,14 @@ const expectedManifest = {
         "assets/preload-helper.js",
         "assets/log.js",
       ],
-      matches: ["https://*/*", "http://*/*", "http://example.com/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/*",
+        "https://example.com/*",
+      ],
       use_dynamic_url: true,
     },
   ],

--- a/test/fixture/index/javascript/manifestV3/contentWithNoImports.ts
+++ b/test/fixture/index/javascript/manifestV3/contentWithNoImports.ts
@@ -7,7 +7,14 @@ const inputManifest = {
   content_scripts: [
     {
       js: [`${resourceDir}/content.js`],
-      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/subpath/*",
+        "https://example.com/subpath/*",
+      ],
     },
   ],
 };
@@ -16,7 +23,14 @@ const expectedManifest = {
   content_scripts: [
     {
       js: [`assets/${resourceDir}/content.js`],
-      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/subpath/*",
+        "https://example.com/subpath/*",
+      ],
     },
   ],
 };

--- a/test/fixture/index/javascript/manifestV3/contentWithSameScriptName.ts
+++ b/test/fixture/index/javascript/manifestV3/contentWithSameScriptName.ts
@@ -7,11 +7,25 @@ const inputManifest = {
   content_scripts: [
     {
       js: [`${resourceDir}/content1/content.js`],
-      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/subpath/*",
+        "https://example.com/subpath/*",
+      ],
     },
     {
       js: [`${resourceDir}/content2/content.js`],
-      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/subpath/*",
+        "https://example.com/subpath/*",
+      ],
     },
   ],
 };
@@ -20,11 +34,25 @@ const expectedManifest = {
   content_scripts: [
     {
       js: [`assets/${resourceDir}/content1/content.js`],
-      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/subpath/*",
+        "https://example.com/subpath/*",
+      ],
     },
     {
       js: [`assets/${resourceDir}/content2/content.js`],
-      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/subpath/*",
+        "https://example.com/subpath/*",
+      ],
     },
   ],
 };

--- a/test/fixture/index/javascript/manifestV3/contentWithUnchunkedImport.ts
+++ b/test/fixture/index/javascript/manifestV3/contentWithUnchunkedImport.ts
@@ -8,7 +8,14 @@ const inputManifest = {
   content_scripts: [
     {
       js: [`${resourceDir}/content.js`],
-      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/subpath/*",
+        "https://example.com/subpath/*",
+      ],
     },
   ],
 };
@@ -17,7 +24,14 @@ const expectedManifest = {
   content_scripts: [
     {
       js: [`assets/${resourceDir}/content.js`],
-      matches: ["https://*/*", "http://*/*", "http://example.com/subpath/*"],
+      matches: [
+        "*://*/*",
+        "https://*/*",
+        "*://example.com/",
+        "https://example.com/",
+        "*://example.com/subpath/*",
+        "https://example.com/subpath/*",
+      ],
     },
   ],
 };


### PR DESCRIPTION
handles content script match patterns like `*://*/*` correctly