### PR TITLE
fix: web accessible scripts with no loader have incorrect filename

### DIFF
--- a/src/manifestParser/manifestParser.ts
+++ b/src/manifestParser/manifestParser.ts
@@ -225,7 +225,7 @@ export default abstract class ManifestParser<
     result.emitFiles.push({
       type: "asset",
       fileName: scriptLoaderFile.fileName,
-      source: scriptLoaderFile.source ?? chunkInfo.code,
+      source: scriptLoaderFile.source,
     });
 
     const metadata = this.getMetadataforChunk(

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -63,7 +63,8 @@ export function getWebAccessibleScriptLoaderForOutputChunk(
 ): { fileName: string; source?: string } {
   if (!chunk.imports.length && !chunk.dynamicImports.length) {
     return {
-      fileName: chunk.fileName,
+      fileName: contentScriptFileName,
+      source: chunk.code,
     };
   }
 

--- a/test/manifest/__snapshots__/fullExtension.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/fullExtension.v2.test.ts.snap
@@ -157,6 +157,37 @@ console.log(chrome.runtime.getURL(\\"src/lib.js\\"));",
     },
   },
   {
+    "code": "console.log(\\"lib.js\\");
+",
+    "dynamicImports": [],
+    "exports": [],
+    "facadeModuleId": "/mocked-repo-dir/test/manifest/resources/fullExtension/src/lib.js",
+    "fileName": "assets/test/manifest/resources/fullExtension/src/lib.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": true,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "/mocked-repo-dir/test/manifest/resources/fullExtension/src/lib.js": {
+        "code": "console.log(\\"lib.js\\");",
+        "originalLength": 23,
+        "removedExports": [],
+        "renderedExports": [],
+        "renderedLength": 22,
+      },
+    },
+    "name": "test/manifest/resources/fullExtension/src/lib",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "browser.runtime.onInstalled.addListener(() => {
   console.log(\\"Extension installed\\");
 });
@@ -3294,13 +3325,6 @@ export {
     "type": "asset",
   },
   {
-    "fileName": "assets/test/manifest/resources/fullExtension/src/lib.js",
-    "name": undefined,
-    "source": "console.log(\\"lib.js\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "assets/index.css",
     "name": "test/manifest/resources/fullExtension/src/entries/options/index.css",
     "source": "#app {
@@ -3370,6 +3394,13 @@ img {
     "type": "asset",
   },
   {
+    "fileName": "test/manifest/resources/fullExtension/src/lib.js",
+    "name": undefined,
+    "source": "console.log(\\"lib.js\\");
+",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js",
     "name": undefined,
     "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js\\"))})();",
@@ -3398,6 +3429,7 @@ img {
   ],
   \\"web_accessible_resources\\": [
     \\"test/manifest/resources/fullExtension/src/lib.js\\",
+    \\"assets/test/manifest/resources/fullExtension/src/lib.js\\",
     \\"assets/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js\\",
     \\"assets/logo.js\\",
     \\"assets/logo.svg\\",

--- a/test/manifest/__snapshots__/fullExtension.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/fullExtension.v3.test.ts.snap
@@ -157,6 +157,37 @@ console.log(chrome.runtime.getURL(\\"src/lib.js\\"));",
     },
   },
   {
+    "code": "console.log(\\"lib.js\\");
+",
+    "dynamicImports": [],
+    "exports": [],
+    "facadeModuleId": "/mocked-repo-dir/test/manifest/resources/fullExtension/src/lib.js",
+    "fileName": "assets/test/manifest/resources/fullExtension/src/lib.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": true,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "/mocked-repo-dir/test/manifest/resources/fullExtension/src/lib.js": {
+        "code": "console.log(\\"lib.js\\");",
+        "originalLength": 23,
+        "removedExports": [],
+        "renderedExports": [],
+        "renderedLength": 22,
+      },
+    },
+    "name": "test/manifest/resources/fullExtension/src/lib",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "browser.runtime.onInstalled.addListener(() => {
   console.log(\\"Extension installed\\");
 });
@@ -3287,13 +3318,6 @@ export {
     "type": "asset",
   },
   {
-    "fileName": "assets/test/manifest/resources/fullExtension/src/lib.js",
-    "name": undefined,
-    "source": "console.log(\\"lib.js\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "assets/index.css",
     "name": "test/manifest/resources/fullExtension/src/entries/options/index.css",
     "source": "#app {
@@ -3356,6 +3380,13 @@ img {
     "type": "asset",
   },
   {
+    "fileName": "test/manifest/resources/fullExtension/src/lib.js",
+    "name": undefined,
+    "source": "console.log(\\"lib.js\\");
+",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js",
     "name": undefined,
     "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js\\"))})();",
@@ -3413,7 +3444,8 @@ img {
         \\"<all_urls>\\"
       ],
       \\"resources\\": [
-        \\"test/manifest/resources/fullExtension/src/lib.js\\"
+        \\"test/manifest/resources/fullExtension/src/lib.js\\",
+        \\"assets/test/manifest/resources/fullExtension/src/lib.js\\"
       ]
     },
     {

--- a/test/manifest/__snapshots__/webAccessibleScriptWithNoImport.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/webAccessibleScriptWithNoImport.v2.test.ts.snap
@@ -3,7 +3,38 @@
 exports[`webAccessibleScriptWithNoImport - Manifest V2 1`] = `
 [
   {
+    "code": "console.log(\\"webAccessibleScript\\");
+",
+    "dynamicImports": [],
+    "exports": [],
+    "facadeModuleId": "/mocked-repo-dir/test/manifest/resources/webAccessibleScriptWithNoImport/webAccessibleScript.js",
     "fileName": "assets/test/manifest/resources/webAccessibleScriptWithNoImport/webAccessibleScript.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": true,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "/mocked-repo-dir/test/manifest/resources/webAccessibleScriptWithNoImport/webAccessibleScript.js": {
+        "code": "console.log(\\"webAccessibleScript\\");",
+        "originalLength": 36,
+        "removedExports": [],
+        "renderedExports": [],
+        "renderedLength": 35,
+      },
+    },
+    "name": "test/manifest/resources/webAccessibleScriptWithNoImport/webAccessibleScript",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
+    "fileName": "test/manifest/resources/webAccessibleScriptWithNoImport/webAccessibleScript.js",
     "name": undefined,
     "source": "console.log(\\"webAccessibleScript\\");
 ",
@@ -17,7 +48,8 @@ exports[`webAccessibleScriptWithNoImport - Manifest V2 1`] = `
   \\"name\\": \\"Manifest Name\\",
   \\"manifest_version\\": 2,
   \\"web_accessible_resources\\": [
-    \\"test/manifest/resources/webAccessibleScriptWithNoImport/webAccessibleScript.js\\"
+    \\"test/manifest/resources/webAccessibleScriptWithNoImport/webAccessibleScript.js\\",
+    \\"assets/test/manifest/resources/webAccessibleScriptWithNoImport/webAccessibleScript.js\\"
   ]
 }",
     "type": "asset",

--- a/test/manifest/__snapshots__/webAccessibleScriptWithNoImport.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/webAccessibleScriptWithNoImport.v3.test.ts.snap
@@ -3,7 +3,38 @@
 exports[`webAccessibleScriptWithNoImport - Manifest V3 1`] = `
 [
   {
+    "code": "console.log(\\"webAccessibleScript\\");
+",
+    "dynamicImports": [],
+    "exports": [],
+    "facadeModuleId": "/mocked-repo-dir/test/manifest/resources/webAccessibleScriptWithNoImport/webAccessibleScript.js",
     "fileName": "assets/test/manifest/resources/webAccessibleScriptWithNoImport/webAccessibleScript.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": true,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "/mocked-repo-dir/test/manifest/resources/webAccessibleScriptWithNoImport/webAccessibleScript.js": {
+        "code": "console.log(\\"webAccessibleScript\\");",
+        "originalLength": 36,
+        "removedExports": [],
+        "renderedExports": [],
+        "renderedLength": 35,
+      },
+    },
+    "name": "test/manifest/resources/webAccessibleScriptWithNoImport/webAccessibleScript",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
+    "fileName": "test/manifest/resources/webAccessibleScriptWithNoImport/webAccessibleScript.js",
     "name": undefined,
     "source": "console.log(\\"webAccessibleScript\\");
 ",
@@ -19,7 +50,8 @@ exports[`webAccessibleScriptWithNoImport - Manifest V3 1`] = `
   \\"web_accessible_resources\\": [
     {
       \\"resources\\": [
-        \\"test/manifest/resources/webAccessibleScriptWithNoImport/webAccessibleScript.js\\"
+        \\"test/manifest/resources/webAccessibleScriptWithNoImport/webAccessibleScript.js\\",
+        \\"assets/test/manifest/resources/webAccessibleScriptWithNoImport/webAccessibleScript.js\\"
       ],
       \\"matches\\": [
         \\"https://*/*\\",

--- a/test/manifest/__snapshots__/webAccessibleScriptWithUnchunkedImport.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/webAccessibleScriptWithUnchunkedImport.v2.test.ts.snap
@@ -1,0 +1,75 @@
+// Vitest Snapshot v1
+
+exports[`webAccessibleScriptWithUnchunkedImport - Manifest V2 1`] = `
+[
+  {
+    "code": "function log(message) {
+  console.log(message);
+}
+log(\\"webAccessibleScript\\");
+",
+    "dynamicImports": [],
+    "exports": [],
+    "facadeModuleId": "/mocked-repo-dir/test/manifest/resources/webAccessibleScriptWithUnchunkedImport/webAccessibleScript.js",
+    "fileName": "assets/test/manifest/resources/webAccessibleScriptWithUnchunkedImport/webAccessibleScript.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": true,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "/mocked-repo-dir/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+      "/mocked-repo-dir/test/manifest/resources/webAccessibleScriptWithUnchunkedImport/webAccessibleScript.js": {
+        "code": "log(\\"webAccessibleScript\\");",
+        "originalLength": 64,
+        "removedExports": [],
+        "renderedExports": [],
+        "renderedLength": 27,
+      },
+    },
+    "name": "test/manifest/resources/webAccessibleScriptWithUnchunkedImport/webAccessibleScript",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
+    "fileName": "test/manifest/resources/webAccessibleScriptWithUnchunkedImport/webAccessibleScript.js",
+    "name": undefined,
+    "source": "function log(message) {
+  console.log(message);
+}
+log(\\"webAccessibleScript\\");
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 2,
+  \\"web_accessible_resources\\": [
+    \\"test/manifest/resources/webAccessibleScriptWithUnchunkedImport/webAccessibleScript.js\\",
+    \\"assets/test/manifest/resources/webAccessibleScriptWithUnchunkedImport/webAccessibleScript.js\\"
+  ]
+}",
+    "type": "asset",
+  },
+]
+`;

--- a/test/manifest/__snapshots__/webAccessibleScriptWithUnchunkedImport.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/webAccessibleScriptWithUnchunkedImport.v3.test.ts.snap
@@ -1,0 +1,83 @@
+// Vitest Snapshot v1
+
+exports[`webAccessibleScriptWithUnchunkedImport - Manifest V3 1`] = `
+[
+  {
+    "code": "function log(message) {
+  console.log(message);
+}
+log(\\"webAccessibleScript\\");
+",
+    "dynamicImports": [],
+    "exports": [],
+    "facadeModuleId": "/mocked-repo-dir/test/manifest/resources/webAccessibleScriptWithUnchunkedImport/webAccessibleScript.js",
+    "fileName": "assets/test/manifest/resources/webAccessibleScriptWithUnchunkedImport/webAccessibleScript.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": true,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "/mocked-repo-dir/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+      "/mocked-repo-dir/test/manifest/resources/webAccessibleScriptWithUnchunkedImport/webAccessibleScript.js": {
+        "code": "log(\\"webAccessibleScript\\");",
+        "originalLength": 64,
+        "removedExports": [],
+        "renderedExports": [],
+        "renderedLength": 27,
+      },
+    },
+    "name": "test/manifest/resources/webAccessibleScriptWithUnchunkedImport/webAccessibleScript",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
+    "fileName": "test/manifest/resources/webAccessibleScriptWithUnchunkedImport/webAccessibleScript.js",
+    "name": undefined,
+    "source": "function log(message) {
+  console.log(message);
+}
+log(\\"webAccessibleScript\\");
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 3,
+  \\"web_accessible_resources\\": [
+    {
+      \\"resources\\": [
+        \\"test/manifest/resources/webAccessibleScriptWithUnchunkedImport/webAccessibleScript.js\\",
+        \\"assets/test/manifest/resources/webAccessibleScriptWithUnchunkedImport/webAccessibleScript.js\\"
+      ],
+      \\"matches\\": [
+        \\"https://*/*\\",
+        \\"http://*/*\\"
+      ]
+    }
+  ]
+}",
+    "type": "asset",
+  },
+]
+`;

--- a/test/manifest/resources/webAccessibleScriptWithUnchunkedImport/webAccessibleScript.js
+++ b/test/manifest/resources/webAccessibleScriptWithUnchunkedImport/webAccessibleScript.js
@@ -1,0 +1,3 @@
+import log from "./../shared/log";
+
+log("webAccessibleScript");

--- a/test/manifest/webAccessibleScriptWithUnchunkedImport.v2.test.ts
+++ b/test/manifest/webAccessibleScriptWithUnchunkedImport.v2.test.ts
@@ -1,0 +1,7 @@
+import { getResourceDir, runManifestV2Test } from "./manifestTestUtils";
+
+const resourceDir = getResourceDir("webAccessibleScriptWithUnchunkedImport");
+
+runManifestV2Test("webAccessibleScriptWithUnchunkedImport", () => ({
+  web_accessible_resources: [`${resourceDir}/webAccessibleScript.js`],
+}));

--- a/test/manifest/webAccessibleScriptWithUnchunkedImport.v3.test.ts
+++ b/test/manifest/webAccessibleScriptWithUnchunkedImport.v3.test.ts
@@ -1,0 +1,12 @@
+import { getResourceDir, runManifestV3Test } from "./manifestTestUtils";
+
+const resourceDir = getResourceDir("webAccessibleScriptWithUnchunkedImport");
+
+runManifestV3Test("webAccessibleScriptWithUnchunkedImport", () => ({
+  web_accessible_resources: [
+    {
+      resources: [`${resourceDir}/webAccessibleScript.js`],
+      matches: ["https://*/*", "http://*/*"],
+    },
+  ],
+}));


### PR DESCRIPTION
should maintain the input filename instead of using chunked filename
