### PR TITLE
DevBuilder’s output path should respect the `root` property of ViteConfig

### DIFF
--- a/src/devBuilder/devBuilder.ts
+++ b/src/devBuilder/devBuilder.ts
@@ -26,7 +26,11 @@ export default abstract class DevBuilder<
     private pluginOptions: ViteWebExtensionOptions,
     private viteDevServer?: ViteDevServer
   ) {
-    this.outDir = this.viteConfig.build.outDir;
+    this.outDir = path.resolve(
+      process.cwd(),
+      this.viteConfig.root,
+      this.viteConfig.build.outDir
+    );
 
     this.webAccessibleScriptsFilter = createWebAccessibleScriptsFilter(
       this.pluginOptions.webAccessibleScripts
@@ -45,7 +49,12 @@ export default abstract class DevBuilder<
     this.hmrServerOrigin = this.getHmrServerOrigin(devServerPort);
 
     await emptyDir(this.outDir);
-    copy("public", this.outDir);
+    const publicDir = path.resolve(
+      process.cwd(),
+      this.viteConfig.root,
+      this.viteConfig.publicDir
+    );
+    copy(publicDir, this.outDir);
 
     await this.writeManifestHtmlFiles(manifestHtmlFiles);
     await this.writeManifestContentScriptFiles(manifest);


### PR DESCRIPTION
I noticed some issues while using this plugin.

1. ***DevBuilder*'s `ourDir` is not consistent.**

    Looking at the code written, I think you intended to refer to the same location as `outDir` in *ViteConfig*.
    But it doesn't work if `$(cwd)` is not the same as the `root` of *ViteConfig*.
    So I modified *outDir*'s path resolution logic to refer to the `root` of *ViteConfig*.

2. ***DevBuilder* always tries to copy the `$(cwd)/public` directory.**

    This path must also be determined by referring to the `root` of *ViteConfig*, not `$(cwd)`.
    And the `publicDir` property of *ViteConfig*, not const literal `"public"`.
    So I modified them to do so.

Thank you so much for creating this good plugin.