### PR TITLE
test: ensure build output for snapshot tests is in a consistent order

### DIFF
--- a/test/manifest/__snapshots__/additionalInputsHtml.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/additionalInputsHtml.v2.test.ts.snap
@@ -3,6 +3,15 @@
 exports[`additionalInputsHtml - Manifest V2 1`] = `
 [
   {
+    "fileName": "assets/html.css",
+    "name": "html.css",
+    "source": "body {
+  color: red;
+}
+",
+    "type": "asset",
+  },
+  {
     "code": "function log(message) {
   console.log(message);
 }
@@ -67,12 +76,16 @@ const style = \\"\\";
     },
   },
   {
-    "fileName": "assets/html.css",
-    "name": "html.css",
-    "source": "body {
-  color: red;
-}
-",
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 2,
+  \\"web_accessible_resources\\": [
+    \\"test/manifest/resources/additionalInputsHtml/html.html\\"
+  ]
+}",
     "type": "asset",
   },
   {
@@ -91,19 +104,6 @@ const style = \\"\\";
   </head>
 </html>
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 2,
-  \\"web_accessible_resources\\": [
-    \\"test/manifest/resources/additionalInputsHtml/html.html\\"
-  ]
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/additionalInputsHtml.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/additionalInputsHtml.v3.test.ts.snap
@@ -3,6 +3,15 @@
 exports[`additionalInputsHtml - Manifest V3 1`] = `
 [
   {
+    "fileName": "assets/html.css",
+    "name": "html.css",
+    "source": "body {
+  color: red;
+}
+",
+    "type": "asset",
+  },
+  {
     "code": "function log(message) {
   console.log(message);
 }
@@ -67,33 +76,6 @@ const style = \\"\\";
     },
   },
   {
-    "fileName": "assets/html.css",
-    "name": "html.css",
-    "source": "body {
-  color: red;
-}
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsHtml/html.html",
-    "name": undefined,
-    "source": "<!DOCTYPE html>
-<html lang=\\"en\\">
-  <head>
-    <meta charset=\\"UTF-8\\" />
-    
-
-    
-    <script type=\\"module\\" src=\\"http://example.com/httpModuleScript.js\\"></script>
-    <script type=\\"module\\" crossorigin src=\\"/assets/test/manifest/resources/additionalInputsHtml/html.js\\"></script>
-    <link rel=\\"stylesheet\\" href=\\"/assets/html.css\\">
-  </head>
-</html>
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -112,6 +94,24 @@ const style = \\"\\";
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsHtml/html.html",
+    "name": undefined,
+    "source": "<!DOCTYPE html>
+<html lang=\\"en\\">
+  <head>
+    <meta charset=\\"UTF-8\\" />
+    
+
+    
+    <script type=\\"module\\" src=\\"http://example.com/httpModuleScript.js\\"></script>
+    <script type=\\"module\\" crossorigin src=\\"/assets/test/manifest/resources/additionalInputsHtml/html.js\\"></script>
+    <link rel=\\"stylesheet\\" href=\\"/assets/html.css\\">
+  </head>
+</html>
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/additionalInputsScriptsChunkedImport.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/additionalInputsScriptsChunkedImport.v2.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`additionalInputsScriptsChunkedImport - Manifest V2 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as l
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "l",
+    ],
+    "facadeModuleId": null,
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "import { l as log } from \\"../../../../log.js\\";
 log(\\"script1\\");
 ",
@@ -79,60 +121,6 @@ log(\\"script2\\");
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as l
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "l",
-    ],
-    "facadeModuleId": null,
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
-}",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsScriptsChunkedImport/script1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsScriptsChunkedImport/script1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsScriptsChunkedImport/script2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsScriptsChunkedImport/script2.js\\"))})();",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -147,6 +135,18 @@ export {
     \\"test/manifest/resources/additionalInputsScriptsChunkedImport/script2.js\\"
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsScriptsChunkedImport/script1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsScriptsChunkedImport/script1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsScriptsChunkedImport/script2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsScriptsChunkedImport/script2.js\\"))})();",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/additionalInputsScriptsChunkedImport.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/additionalInputsScriptsChunkedImport.v3.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`additionalInputsScriptsChunkedImport - Manifest V3 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as l
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "l",
+    ],
+    "facadeModuleId": null,
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "import { l as log } from \\"../../../../log.js\\";
 log(\\"script1\\");
 ",
@@ -79,60 +121,6 @@ log(\\"script2\\");
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as l
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "l",
-    ],
-    "facadeModuleId": null,
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
-}",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsScriptsChunkedImport/script1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsScriptsChunkedImport/script1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsScriptsChunkedImport/script2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsScriptsChunkedImport/script2.js\\"))})();",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -155,6 +143,18 @@ export {
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsScriptsChunkedImport/script1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsScriptsChunkedImport/script1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsScriptsChunkedImport/script2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsScriptsChunkedImport/script2.js\\"))})();",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/additionalInputsScriptsNoImport.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/additionalInputsScriptsNoImport.v2.test.ts.snap
@@ -3,20 +3,6 @@
 exports[`additionalInputsScriptsNoImport - Manifest V2 1`] = `
 [
   {
-    "fileName": "test/manifest/resources/additionalInputsScriptsNoImport/script1.js",
-    "name": undefined,
-    "source": "console.log(\\"script1\\");
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsScriptsNoImport/script2.js",
-    "name": undefined,
-    "source": "console.log(\\"script2\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -28,6 +14,20 @@ exports[`additionalInputsScriptsNoImport - Manifest V2 1`] = `
     \\"test/manifest/resources/additionalInputsScriptsNoImport/script2.js\\"
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsScriptsNoImport/script1.js",
+    "name": undefined,
+    "source": "console.log(\\"script1\\");
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsScriptsNoImport/script2.js",
+    "name": undefined,
+    "source": "console.log(\\"script2\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/additionalInputsScriptsNoImport.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/additionalInputsScriptsNoImport.v3.test.ts.snap
@@ -3,20 +3,6 @@
 exports[`additionalInputsScriptsNoImport - Manifest V3 1`] = `
 [
   {
-    "fileName": "test/manifest/resources/additionalInputsScriptsNoImport/script1.js",
-    "name": undefined,
-    "source": "console.log(\\"script1\\");
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsScriptsNoImport/script2.js",
-    "name": undefined,
-    "source": "console.log(\\"script2\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -36,6 +22,20 @@ exports[`additionalInputsScriptsNoImport - Manifest V3 1`] = `
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsScriptsNoImport/script1.js",
+    "name": undefined,
+    "source": "console.log(\\"script1\\");
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsScriptsNoImport/script2.js",
+    "name": undefined,
+    "source": "console.log(\\"script2\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/additionalInputsScriptsTypes.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/additionalInputsScriptsTypes.v2.test.ts.snap
@@ -3,20 +3,6 @@
 exports[`additionalInputsScriptsTypes - Manifest V2 1`] = `
 [
   {
-    "fileName": "test/manifest/resources/additionalInputsScriptsTypes/script1.js",
-    "name": undefined,
-    "source": "console.log(\\"script1\\");
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsScriptsTypes/script2.js",
-    "name": undefined,
-    "source": "console.log(\\"script2\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -28,6 +14,20 @@ exports[`additionalInputsScriptsTypes - Manifest V2 1`] = `
     \\"test/manifest/resources/additionalInputsScriptsTypes/script2.js\\"
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsScriptsTypes/script1.js",
+    "name": undefined,
+    "source": "console.log(\\"script1\\");
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsScriptsTypes/script2.js",
+    "name": undefined,
+    "source": "console.log(\\"script2\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/additionalInputsScriptsTypes.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/additionalInputsScriptsTypes.v3.test.ts.snap
@@ -3,20 +3,6 @@
 exports[`additionalInputsScriptsTypes - Manifest V3 1`] = `
 [
   {
-    "fileName": "test/manifest/resources/additionalInputsScriptsTypes/script1.js",
-    "name": undefined,
-    "source": "console.log(\\"script1\\");
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsScriptsTypes/script2.js",
-    "name": undefined,
-    "source": "console.log(\\"script2\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -36,6 +22,20 @@ exports[`additionalInputsScriptsTypes - Manifest V3 1`] = `
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsScriptsTypes/script1.js",
+    "name": undefined,
+    "source": "console.log(\\"script1\\");
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsScriptsTypes/script2.js",
+    "name": undefined,
+    "source": "console.log(\\"script2\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/additionalInputsScriptsUnchunkedImport.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/additionalInputsScriptsUnchunkedImport.v2.test.ts.snap
@@ -3,6 +3,20 @@
 exports[`additionalInputsScriptsUnchunkedImport - Manifest V2 1`] = `
 [
   {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 2,
+  \\"web_accessible_resources\\": [
+    \\"test/manifest/resources/additionalInputsScriptsUnchunkedImport/script1.js\\",
+    \\"test/manifest/resources/additionalInputsScriptsUnchunkedImport/script2.js\\"
+  ]
+}",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/additionalInputsScriptsUnchunkedImport/script1.js",
     "name": undefined,
     "source": "function log(message) {
@@ -17,20 +31,6 @@ log(\\"script1\\");
     "name": undefined,
     "source": "console.log(\\"script2\\");
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 2,
-  \\"web_accessible_resources\\": [
-    \\"test/manifest/resources/additionalInputsScriptsUnchunkedImport/script1.js\\",
-    \\"test/manifest/resources/additionalInputsScriptsUnchunkedImport/script2.js\\"
-  ]
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/additionalInputsScriptsUnchunkedImport.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/additionalInputsScriptsUnchunkedImport.v3.test.ts.snap
@@ -3,23 +3,6 @@
 exports[`additionalInputsScriptsUnchunkedImport - Manifest V3 1`] = `
 [
   {
-    "fileName": "test/manifest/resources/additionalInputsScriptsUnchunkedImport/script1.js",
-    "name": undefined,
-    "source": "function log(message) {
-  console.log(message);
-}
-log(\\"script1\\");
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsScriptsUnchunkedImport/script2.js",
-    "name": undefined,
-    "source": "console.log(\\"script2\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -39,6 +22,23 @@ log(\\"script1\\");
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsScriptsUnchunkedImport/script1.js",
+    "name": undefined,
+    "source": "function log(message) {
+  console.log(message);
+}
+log(\\"script1\\");
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsScriptsUnchunkedImport/script2.js",
+    "name": undefined,
+    "source": "console.log(\\"script2\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/additionalInputsStylesTypes.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/additionalInputsStylesTypes.v2.test.ts.snap
@@ -3,6 +3,20 @@
 exports[`additionalInputsStylesTypes - Manifest V2 1`] = `
 [
   {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 2,
+  \\"web_accessible_resources\\": [
+    \\"test/manifest/resources/additionalInputsStylesTypes/style1.css\\",
+    \\"test/manifest/resources/additionalInputsStylesTypes/style2.css\\"
+  ]
+}",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/additionalInputsStylesTypes/style1.css",
     "name": undefined,
     "source": "body {
@@ -16,20 +30,6 @@ exports[`additionalInputsStylesTypes - Manifest V2 1`] = `
     "name": undefined,
     "source": "body {
   color: green;
-}",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 2,
-  \\"web_accessible_resources\\": [
-    \\"test/manifest/resources/additionalInputsStylesTypes/style1.css\\",
-    \\"test/manifest/resources/additionalInputsStylesTypes/style2.css\\"
-  ]
 }",
     "type": "asset",
   },

--- a/test/manifest/__snapshots__/additionalInputsStylesTypes.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/additionalInputsStylesTypes.v3.test.ts.snap
@@ -3,23 +3,6 @@
 exports[`additionalInputsStylesTypes - Manifest V3 1`] = `
 [
   {
-    "fileName": "test/manifest/resources/additionalInputsStylesTypes/style1.css",
-    "name": undefined,
-    "source": "body {
-  color: red;
-}
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsStylesTypes/style2.css",
-    "name": undefined,
-    "source": "body {
-  color: green;
-}",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -38,6 +21,23 @@ exports[`additionalInputsStylesTypes - Manifest V3 1`] = `
       \\"use_dynamic_url\\": true
     }
   ]
+}",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsStylesTypes/style1.css",
+    "name": undefined,
+    "source": "body {
+  color: red;
+}
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsStylesTypes/style2.css",
+    "name": undefined,
+    "source": "body {
+  color: green;
 }",
     "type": "asset",
   },

--- a/test/manifest/__snapshots__/additionalInputsWebAccessible.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/additionalInputsWebAccessible.v2.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`additionalInputsWebAccessible - Manifest V2 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as l
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "l",
+    ],
+    "facadeModuleId": null,
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "import { l as log } from \\"../../../../log.js\\";
 log(\\"chunkedScript1\\");
 ",
@@ -117,46 +159,45 @@ log(\\"chunkedScript3\\");
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as l
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "l",
-    ],
-    "facadeModuleId": null,
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 2,
+  \\"web_accessible_resources\\": [
+    \\"assets/log.js\\",
+    \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\",
+    \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\",
+    \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js\\",
+    \\"test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\",
+    \\"test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\",
+    \\"test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js\\",
+    \\"test/manifest/resources/additionalInputsWebAccessible/script1.js\\",
+    \\"test/manifest/resources/additionalInputsWebAccessible/script3.js\\",
+    \\"test/manifest/resources/additionalInputsWebAccessible/script4.js\\",
+    \\"test/manifest/resources/additionalInputsWebAccessible/script5.js\\"
+  ]
 }",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js\\"))})();",
+    "type": "asset",
   },
   {
     "fileName": "test/manifest/resources/additionalInputsWebAccessible/script1.js",
@@ -191,47 +232,6 @@ export {
     "name": undefined,
     "source": "console.log(\\"script5\\");
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 2,
-  \\"web_accessible_resources\\": [
-    \\"assets/log.js\\",
-    \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\",
-    \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\",
-    \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js\\",
-    \\"test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\",
-    \\"test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\",
-    \\"test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js\\",
-    \\"test/manifest/resources/additionalInputsWebAccessible/script1.js\\",
-    \\"test/manifest/resources/additionalInputsWebAccessible/script3.js\\",
-    \\"test/manifest/resources/additionalInputsWebAccessible/script4.js\\",
-    \\"test/manifest/resources/additionalInputsWebAccessible/script5.js\\"
-  ]
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/additionalInputsWebAccessible.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/additionalInputsWebAccessible.v3.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`additionalInputsWebAccessible - Manifest V3 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as l
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "l",
+    ],
+    "facadeModuleId": null,
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "import { l as log } from \\"../../../../log.js\\";
 log(\\"chunkedScript1\\");
 ",
@@ -117,101 +159,6 @@ log(\\"chunkedScript3\\");
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as l
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "l",
-    ],
-    "facadeModuleId": null,
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
-}",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/script1.js",
-    "name": undefined,
-    "source": "console.log(\\"script1\\");
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/script2.js",
-    "name": undefined,
-    "source": "console.log(\\"script2\\");
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/script3.js",
-    "name": undefined,
-    "source": "console.log(\\"script3\\");
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/script4.js",
-    "name": undefined,
-    "source": "console.log(\\"script4\\");
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/script5.js",
-    "name": undefined,
-    "source": "console.log(\\"script5\\");
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js\\"))})();",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -257,6 +204,59 @@ export {
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/script1.js",
+    "name": undefined,
+    "source": "console.log(\\"script1\\");
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/script2.js",
+    "name": undefined,
+    "source": "console.log(\\"script2\\");
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/script3.js",
+    "name": undefined,
+    "source": "console.log(\\"script3\\");
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/script4.js",
+    "name": undefined,
+    "source": "console.log(\\"script4\\");
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/script5.js",
+    "name": undefined,
+    "source": "console.log(\\"script5\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/additionalInputsWebAccessibleExcludeEntryFile.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/additionalInputsWebAccessibleExcludeEntryFile.v2.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`additionalInputsWebAccessible - Manifest V2 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as l
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "l",
+    ],
+    "facadeModuleId": null,
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "import { l as log } from \\"../../../../log.js\\";
 log(\\"chunkedScript1\\");
 ",
@@ -117,46 +159,45 @@ log(\\"chunkedScript3\\");
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as l
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "l",
-    ],
-    "facadeModuleId": null,
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 2,
+  \\"web_accessible_resources\\": [
+    \\"assets/log.js\\",
+    \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\",
+    \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\",
+    \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js\\",
+    \\"test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\",
+    \\"test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\",
+    \\"test/manifest/resources/additionalInputsWebAccessible/script1.js\\",
+    \\"test/manifest/resources/additionalInputsWebAccessible/script2.js\\",
+    \\"test/manifest/resources/additionalInputsWebAccessible/script3.js\\",
+    \\"test/manifest/resources/additionalInputsWebAccessible/script5.js\\",
+    \\"test/manifest/resources/additionalInputsWebAccessible/script6.js\\"
+  ]
 }",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js\\"))})();",
+    "type": "asset",
   },
   {
     "fileName": "test/manifest/resources/additionalInputsWebAccessible/script1.js",
@@ -205,47 +246,6 @@ export {
     "name": undefined,
     "source": "console.log(\\"script7\\");
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 2,
-  \\"web_accessible_resources\\": [
-    \\"assets/log.js\\",
-    \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\",
-    \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\",
-    \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js\\",
-    \\"test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\",
-    \\"test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\",
-    \\"test/manifest/resources/additionalInputsWebAccessible/script1.js\\",
-    \\"test/manifest/resources/additionalInputsWebAccessible/script2.js\\",
-    \\"test/manifest/resources/additionalInputsWebAccessible/script3.js\\",
-    \\"test/manifest/resources/additionalInputsWebAccessible/script5.js\\",
-    \\"test/manifest/resources/additionalInputsWebAccessible/script6.js\\"
-  ]
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/additionalInputsWebAccessibleExcludeEntryFile.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/additionalInputsWebAccessibleExcludeEntryFile.v3.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`additionalInputsWebAccessible - Manifest V3 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as l
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "l",
+    ],
+    "facadeModuleId": null,
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "import { l as log } from \\"../../../../log.js\\";
 log(\\"chunkedScript1\\");
 ",
@@ -117,46 +159,69 @@ log(\\"chunkedScript3\\");
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as l
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "l",
-    ],
-    "facadeModuleId": null,
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 3,
+  \\"web_accessible_resources\\": [
+    {
+      \\"resources\\": [
+        \\"test/manifest/resources/additionalInputsWebAccessible/script1.js\\"
+      ],
+      \\"matches\\": [
+        \\"<all_urls>\\"
+      ],
+      \\"use_dynamic_url\\": true
+    },
+    {
+      \\"resources\\": [
+        \\"assets/log.js\\",
+        \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\",
+        \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\",
+        \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js\\",
+        \\"test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\",
+        \\"test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\",
+        \\"test/manifest/resources/additionalInputsWebAccessible/script2.js\\",
+        \\"test/manifest/resources/additionalInputsWebAccessible/script3.js\\"
+      ],
+      \\"matches\\": [
+        \\"https://example.com/\\"
+      ],
+      \\"use_dynamic_url\\": true
+    },
+    {
+      \\"resources\\": [
+        \\"test/manifest/resources/additionalInputsWebAccessible/script5.js\\",
+        \\"test/manifest/resources/additionalInputsWebAccessible/script6.js\\"
+      ],
+      \\"extension_ids\\": [
+        \\"oilkjaldkfjlasdf\\"
+      ],
+      \\"use_dynamic_url\\": true
+    }
+  ]
 }",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js\\"))})();",
+    "type": "asset",
   },
   {
     "fileName": "test/manifest/resources/additionalInputsWebAccessible/script1.js",
@@ -205,71 +270,6 @@ export {
     "name": undefined,
     "source": "console.log(\\"script7\\");
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 3,
-  \\"web_accessible_resources\\": [
-    {
-      \\"resources\\": [
-        \\"test/manifest/resources/additionalInputsWebAccessible/script1.js\\"
-      ],
-      \\"matches\\": [
-        \\"<all_urls>\\"
-      ],
-      \\"use_dynamic_url\\": true
-    },
-    {
-      \\"resources\\": [
-        \\"assets/log.js\\",
-        \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\",
-        \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\",
-        \\"assets/test/manifest/resources/additionalInputsWebAccessible/chunkedScript3.js\\",
-        \\"test/manifest/resources/additionalInputsWebAccessible/chunkedScript1.js\\",
-        \\"test/manifest/resources/additionalInputsWebAccessible/chunkedScript2.js\\",
-        \\"test/manifest/resources/additionalInputsWebAccessible/script2.js\\",
-        \\"test/manifest/resources/additionalInputsWebAccessible/script3.js\\"
-      ],
-      \\"matches\\": [
-        \\"https://example.com/\\"
-      ],
-      \\"use_dynamic_url\\": true
-    },
-    {
-      \\"resources\\": [
-        \\"test/manifest/resources/additionalInputsWebAccessible/script5.js\\",
-        \\"test/manifest/resources/additionalInputsWebAccessible/script6.js\\"
-      ],
-      \\"extension_ids\\": [
-        \\"oilkjaldkfjlasdf\\"
-      ],
-      \\"use_dynamic_url\\": true
-    }
-  ]
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/backgroundHtml.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/backgroundHtml.v2.test.ts.snap
@@ -55,6 +55,20 @@ log(\\"background\\");
     },
   },
   {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 2,
+  \\"background\\": {
+    \\"page\\": \\"test/manifest/resources/backgroundHtml/background.html\\",
+    \\"persistent\\": false
+  }
+}",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/backgroundHtml/background.html",
     "name": undefined,
     "source": "<!DOCTYPE html>
@@ -68,20 +82,6 @@ log(\\"background\\");
   </head>
 </html>
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 2,
-  \\"background\\": {
-    \\"page\\": \\"test/manifest/resources/backgroundHtml/background.html\\",
-    \\"persistent\\": false
-  }
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/backgroundServiceWorker.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/backgroundServiceWorker.v3.test.ts.snap
@@ -34,12 +34,6 @@ exports[`backgroundServiceWorker - Manifest V3 1`] = `
     },
   },
   {
-    "fileName": "serviceWorker.js",
-    "name": undefined,
-    "source": "import \\"/assets/test/manifest/resources/backgroundServiceWorker/serviceWorker.js\\";",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -51,6 +45,12 @@ exports[`backgroundServiceWorker - Manifest V3 1`] = `
     \\"type\\": \\"module\\"
   }
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "serviceWorker.js",
+    "name": undefined,
+    "source": "import \\"/assets/test/manifest/resources/backgroundServiceWorker/serviceWorker.js\\";",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/backgroundServiceWorkerRelative.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/backgroundServiceWorkerRelative.v3.test.ts.snap
@@ -34,12 +34,6 @@ exports[`backgroundServiceWorker - Manifest V3 1`] = `
     },
   },
   {
-    "fileName": "serviceWorker.js",
-    "name": undefined,
-    "source": "import \\"/assets/test/manifest/resources/backgroundServiceWorker/serviceWorker.js\\";",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -51,6 +45,12 @@ exports[`backgroundServiceWorker - Manifest V3 1`] = `
     \\"type\\": \\"module\\"
   }
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "serviceWorker.js",
+    "name": undefined,
+    "source": "import \\"/assets/test/manifest/resources/backgroundServiceWorker/serviceWorker.js\\";",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/backgroundServiceWorkerRoot.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/backgroundServiceWorkerRoot.v3.test.ts.snap
@@ -34,12 +34,6 @@ exports[`backgroundServiceWorker - Manifest V3 1`] = `
     },
   },
   {
-    "fileName": "serviceWorker.js",
-    "name": undefined,
-    "source": "import \\"/assets/test/manifest/resources/backgroundServiceWorker/serviceWorker.js\\";",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -51,6 +45,12 @@ exports[`backgroundServiceWorker - Manifest V3 1`] = `
     \\"type\\": \\"module\\"
   }
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "serviceWorker.js",
+    "name": undefined,
+    "source": "import \\"/assets/test/manifest/resources/backgroundServiceWorker/serviceWorker.js\\";",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/chromeUrlOverridesHtmlBookmarks.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/chromeUrlOverridesHtmlBookmarks.v2.test.ts.snap
@@ -55,6 +55,19 @@ log(\\"chromeUrlOverridesHtml\\");
     },
   },
   {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 2,
+  \\"chrome_url_overrides\\": {
+    \\"bookmarks\\": \\"test/manifest/resources/chromeUrlOverridesHtml/bookmarks.html\\"
+  }
+}",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/chromeUrlOverridesHtml/bookmarks.html",
     "name": undefined,
     "source": "<!DOCTYPE html>
@@ -68,19 +81,6 @@ log(\\"chromeUrlOverridesHtml\\");
   </head>
 </html>
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 2,
-  \\"chrome_url_overrides\\": {
-    \\"bookmarks\\": \\"test/manifest/resources/chromeUrlOverridesHtml/bookmarks.html\\"
-  }
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/chromeUrlOverridesHtmlBookmarks.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/chromeUrlOverridesHtmlBookmarks.v3.test.ts.snap
@@ -55,6 +55,19 @@ log(\\"chromeUrlOverridesHtml\\");
     },
   },
   {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 3,
+  \\"chrome_url_overrides\\": {
+    \\"bookmarks\\": \\"test/manifest/resources/chromeUrlOverridesHtml/bookmarks.html\\"
+  }
+}",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/chromeUrlOverridesHtml/bookmarks.html",
     "name": undefined,
     "source": "<!DOCTYPE html>
@@ -68,19 +81,6 @@ log(\\"chromeUrlOverridesHtml\\");
   </head>
 </html>
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 3,
-  \\"chrome_url_overrides\\": {
-    \\"bookmarks\\": \\"test/manifest/resources/chromeUrlOverridesHtml/bookmarks.html\\"
-  }
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/chromeUrlOverridesHtmlHistory.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/chromeUrlOverridesHtmlHistory.v2.test.ts.snap
@@ -55,6 +55,19 @@ log(\\"chromeUrlOverridesHtml\\");
     },
   },
   {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 2,
+  \\"chrome_url_overrides\\": {
+    \\"history\\": \\"test/manifest/resources/chromeUrlOverridesHtml/history.html\\"
+  }
+}",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/chromeUrlOverridesHtml/history.html",
     "name": undefined,
     "source": "<!DOCTYPE html>
@@ -68,19 +81,6 @@ log(\\"chromeUrlOverridesHtml\\");
   </head>
 </html>
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 2,
-  \\"chrome_url_overrides\\": {
-    \\"history\\": \\"test/manifest/resources/chromeUrlOverridesHtml/history.html\\"
-  }
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/chromeUrlOverridesHtmlHistory.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/chromeUrlOverridesHtmlHistory.v3.test.ts.snap
@@ -55,6 +55,19 @@ log(\\"chromeUrlOverridesHtml\\");
     },
   },
   {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 3,
+  \\"chrome_url_overrides\\": {
+    \\"history\\": \\"test/manifest/resources/chromeUrlOverridesHtml/history.html\\"
+  }
+}",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/chromeUrlOverridesHtml/history.html",
     "name": undefined,
     "source": "<!DOCTYPE html>
@@ -68,19 +81,6 @@ log(\\"chromeUrlOverridesHtml\\");
   </head>
 </html>
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 3,
-  \\"chrome_url_overrides\\": {
-    \\"history\\": \\"test/manifest/resources/chromeUrlOverridesHtml/history.html\\"
-  }
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/chromeUrlOverridesHtmlNewTab.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/chromeUrlOverridesHtmlNewTab.v2.test.ts.snap
@@ -55,6 +55,19 @@ log(\\"chromeUrlOverridesHtml\\");
     },
   },
   {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 2,
+  \\"chrome_url_overrides\\": {
+    \\"newtab\\": \\"test/manifest/resources/chromeUrlOverridesHtml/newtab.html\\"
+  }
+}",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/chromeUrlOverridesHtml/newtab.html",
     "name": undefined,
     "source": "<!DOCTYPE html>
@@ -68,19 +81,6 @@ log(\\"chromeUrlOverridesHtml\\");
   </head>
 </html>
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 2,
-  \\"chrome_url_overrides\\": {
-    \\"newtab\\": \\"test/manifest/resources/chromeUrlOverridesHtml/newtab.html\\"
-  }
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/chromeUrlOverridesHtmlNewTab.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/chromeUrlOverridesHtmlNewTab.v3.test.ts.snap
@@ -55,6 +55,19 @@ log(\\"chromeUrlOverridesHtml\\");
     },
   },
   {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 3,
+  \\"chrome_url_overrides\\": {
+    \\"newtab\\": \\"test/manifest/resources/chromeUrlOverridesHtml/newtab.html\\"
+  }
+}",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/chromeUrlOverridesHtml/newtab.html",
     "name": undefined,
     "source": "<!DOCTYPE html>
@@ -68,19 +81,6 @@ log(\\"chromeUrlOverridesHtml\\");
   </head>
 </html>
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 3,
-  \\"chrome_url_overrides\\": {
-    \\"newtab\\": \\"test/manifest/resources/chromeUrlOverridesHtml/newtab.html\\"
-  }
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/chunkCssRewrite.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/chunkCssRewrite.v2.test.ts.snap
@@ -30,29 +30,6 @@ exports[`chunkCssRewrite - Manifest V2 1`] = `
     "type": "asset",
   },
   {
-    "fileName": "test/manifest/resources/chunkCssRewrite/content1.js",
-    "name": undefined,
-    "source": "/* empty css                         */const content1 = \\"\\";
-console.log([\\"assets/content1.css\\",\\"assets/contentShared.css\\"]);
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/chunkCssRewrite/content2.js",
-    "name": undefined,
-    "source": "/* empty css                         */const content2 = \\"\\";
-console.log([\\"assets/content2.css\\",\\"assets/contentShared.css\\"]);
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/chunkCssRewrite/contentNoCss.js",
-    "name": undefined,
-    "source": "console.log([]);
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -94,6 +71,29 @@ console.log([\\"assets/content2.css\\",\\"assets/contentShared.css\\"]);
     \\"assets/contentShared.css\\"
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/chunkCssRewrite/content1.js",
+    "name": undefined,
+    "source": "/* empty css                         */const content1 = \\"\\";
+console.log([\\"assets/content1.css\\",\\"assets/contentShared.css\\"]);
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/chunkCssRewrite/content2.js",
+    "name": undefined,
+    "source": "/* empty css                         */const content2 = \\"\\";
+console.log([\\"assets/content2.css\\",\\"assets/contentShared.css\\"]);
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/chunkCssRewrite/contentNoCss.js",
+    "name": undefined,
+    "source": "console.log([]);
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/chunkCssRewrite.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/chunkCssRewrite.v3.test.ts.snap
@@ -30,29 +30,6 @@ exports[`chunkCssRewrite - Manifest V3 1`] = `
     "type": "asset",
   },
   {
-    "fileName": "test/manifest/resources/chunkCssRewrite/content1.js",
-    "name": undefined,
-    "source": "/* empty css                         */const content1 = \\"\\";
-console.log([\\"assets/content1.css\\",\\"assets/contentShared.css\\"]);
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/chunkCssRewrite/content2.js",
-    "name": undefined,
-    "source": "/* empty css                         */const content2 = \\"\\";
-console.log([\\"assets/content2.css\\",\\"assets/contentShared.css\\"]);
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/chunkCssRewrite/contentNoCss.js",
-    "name": undefined,
-    "source": "console.log([]);
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -103,6 +80,29 @@ console.log([\\"assets/content2.css\\",\\"assets/contentShared.css\\"]);
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/chunkCssRewrite/content1.js",
+    "name": undefined,
+    "source": "/* empty css                         */const content1 = \\"\\";
+console.log([\\"assets/content1.css\\",\\"assets/contentShared.css\\"]);
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/chunkCssRewrite/content2.js",
+    "name": undefined,
+    "source": "/* empty css                         */const content2 = \\"\\";
+console.log([\\"assets/content2.css\\",\\"assets/contentShared.css\\"]);
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/chunkCssRewrite/contentNoCss.js",
+    "name": undefined,
+    "source": "console.log([]);
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/contentCss.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/contentCss.v2.test.ts.snap
@@ -20,13 +20,6 @@ exports[`contentCss - Manifest V2 1`] = `
     "type": "asset",
   },
   {
-    "fileName": "test/manifest/resources/contentCss/content.js",
-    "name": undefined,
-    "source": "console.log(\\"content\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -49,6 +42,13 @@ exports[`contentCss - Manifest V2 1`] = `
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentCss/content.js",
+    "name": undefined,
+    "source": "console.log(\\"content\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/contentCss.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/contentCss.v3.test.ts.snap
@@ -20,13 +20,6 @@ exports[`contentCss - Manifest V3 1`] = `
     "type": "asset",
   },
   {
-    "fileName": "test/manifest/resources/contentCss/content.js",
-    "name": undefined,
-    "source": "console.log(\\"content\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -49,6 +42,13 @@ exports[`contentCss - Manifest V3 1`] = `
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentCss/content.js",
+    "name": undefined,
+    "source": "console.log(\\"content\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/contentScriptPaths.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/contentScriptPaths.v2.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`contentScriptPaths - Manifest V2 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as l
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "l",
+    ],
+    "facadeModuleId": null,
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "import { l as log } from \\"../../../../log.js\\";
 log(\\"content\\");
 ",
@@ -79,60 +121,6 @@ log(\\"content2\\");
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as l
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "l",
-    ],
-    "facadeModuleId": null,
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
-}",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
-  },
-  {
-    "fileName": "test/manifest/resources/contentWithChunkedImport/content1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithChunkedImport/content1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/contentWithChunkedImport/content2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithChunkedImport/content2.js\\"))})();",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -165,6 +153,18 @@ export {
     \\"assets/test/manifest/resources/contentWithChunkedImport/content2.js\\"
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithChunkedImport/content1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithChunkedImport/content1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithChunkedImport/content2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithChunkedImport/content2.js\\"))})();",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/contentScriptPaths.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/contentScriptPaths.v3.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`contentScriptPaths - Manifest V3 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as l
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "l",
+    ],
+    "facadeModuleId": null,
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "import { l as log } from \\"../../../../log.js\\";
 log(\\"content\\");
 ",
@@ -79,60 +121,6 @@ log(\\"content2\\");
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as l
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "l",
-    ],
-    "facadeModuleId": null,
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
-}",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
-  },
-  {
-    "fileName": "test/manifest/resources/contentWithChunkedImport/content1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithChunkedImport/content1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/contentWithChunkedImport/content2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithChunkedImport/content2.js\\"))})();",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -174,6 +162,18 @@ export {
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithChunkedImport/content1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithChunkedImport/content1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithChunkedImport/content2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithChunkedImport/content2.js\\"))})();",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/contentScriptTypes.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/contentScriptTypes.v2.test.ts.snap
@@ -3,20 +3,6 @@
 exports[`contentScriptTypes - Manifest V2 1`] = `
 [
   {
-    "fileName": "test/manifest/resources/contentScriptTypes/content1.js",
-    "name": undefined,
-    "source": "console.log(\\"content1\\");
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/contentScriptTypes/content2.js",
-    "name": undefined,
-    "source": "console.log(\\"content2\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -42,6 +28,20 @@ exports[`contentScriptTypes - Manifest V2 1`] = `
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentScriptTypes/content1.js",
+    "name": undefined,
+    "source": "console.log(\\"content1\\");
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentScriptTypes/content2.js",
+    "name": undefined,
+    "source": "console.log(\\"content2\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/contentScriptTypes.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/contentScriptTypes.v3.test.ts.snap
@@ -3,20 +3,6 @@
 exports[`contentScriptTypes - Manifest V3 1`] = `
 [
   {
-    "fileName": "test/manifest/resources/contentScriptTypes/content1.js",
-    "name": undefined,
-    "source": "console.log(\\"content1\\");
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/contentScriptTypes/content2.js",
-    "name": undefined,
-    "source": "console.log(\\"content2\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -42,6 +28,20 @@ exports[`contentScriptTypes - Manifest V3 1`] = `
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentScriptTypes/content1.js",
+    "name": undefined,
+    "source": "console.log(\\"content1\\");
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentScriptTypes/content2.js",
+    "name": undefined,
+    "source": "console.log(\\"content2\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/contentWithChunkedImport.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/contentWithChunkedImport.v2.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`contentWithChunkedImport - Manifest V2 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as l
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "l",
+    ],
+    "facadeModuleId": null,
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "import { l as log } from \\"../../../../log.js\\";
 log(\\"content\\");
 ",
@@ -79,60 +121,6 @@ log(\\"content2\\");
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as l
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "l",
-    ],
-    "facadeModuleId": null,
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
-}",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
-  },
-  {
-    "fileName": "test/manifest/resources/contentWithChunkedImport/content1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithChunkedImport/content1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/contentWithChunkedImport/content2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithChunkedImport/content2.js\\"))})();",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -165,6 +153,18 @@ export {
     \\"assets/test/manifest/resources/contentWithChunkedImport/content2.js\\"
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithChunkedImport/content1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithChunkedImport/content1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithChunkedImport/content2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithChunkedImport/content2.js\\"))})();",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/contentWithChunkedImport.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/contentWithChunkedImport.v3.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`contentWithChunkedImport - Manifest V3 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as l
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "l",
+    ],
+    "facadeModuleId": null,
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "import { l as log } from \\"../../../../log.js\\";
 log(\\"content\\");
 ",
@@ -79,60 +121,6 @@ log(\\"content2\\");
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as l
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "l",
-    ],
-    "facadeModuleId": null,
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
-}",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
-  },
-  {
-    "fileName": "test/manifest/resources/contentWithChunkedImport/content1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithChunkedImport/content1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/contentWithChunkedImport/content2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithChunkedImport/content2.js\\"))})();",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -186,6 +174,18 @@ export {
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithChunkedImport/content1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithChunkedImport/content1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithChunkedImport/content2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithChunkedImport/content2.js\\"))})();",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/contentWithDynamicImport.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/contentWithDynamicImport.v2.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`contentWithDynamicImport - Manifest V2 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as default
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "default",
+    ],
+    "facadeModuleId": "vite-plugin-web-extension/test/manifest/resources/shared/log.js",
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": true,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "(async () => {
   const log = await import(\\"../../../../log.js\\");
   log(\\"content\\");
@@ -83,60 +125,6 @@ exports[`contentWithDynamicImport - Manifest V2 1`] = `
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as default
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "default",
-    ],
-    "facadeModuleId": "vite-plugin-web-extension/test/manifest/resources/shared/log.js",
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": true,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
-}",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
-  },
-  {
-    "fileName": "test/manifest/resources/contentWithDynamicImport/content1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithDynamicImport/content1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/contentWithDynamicImport/content2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithDynamicImport/content2.js\\"))})();",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -169,6 +157,18 @@ export {
     \\"assets/test/manifest/resources/contentWithDynamicImport/content2.js\\"
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithDynamicImport/content1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithDynamicImport/content1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithDynamicImport/content2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithDynamicImport/content2.js\\"))})();",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/contentWithDynamicImport.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/contentWithDynamicImport.v3.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`contentWithDynamicImport - Manifest V3 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as default
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "default",
+    ],
+    "facadeModuleId": "vite-plugin-web-extension/test/manifest/resources/shared/log.js",
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": true,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "(async () => {
   const log = await import(\\"../../../../log.js\\");
   log(\\"content\\");
@@ -83,60 +125,6 @@ exports[`contentWithDynamicImport - Manifest V3 1`] = `
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as default
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "default",
-    ],
-    "facadeModuleId": "vite-plugin-web-extension/test/manifest/resources/shared/log.js",
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": true,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
-}",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
-  },
-  {
-    "fileName": "test/manifest/resources/contentWithDynamicImport/content1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithDynamicImport/content1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/contentWithDynamicImport/content2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithDynamicImport/content2.js\\"))})();",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -190,6 +178,18 @@ export {
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithDynamicImport/content1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithDynamicImport/content1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithDynamicImport/content2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/contentWithDynamicImport/content2.js\\"))})();",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/contentWithNoImports.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/contentWithNoImports.v2.test.ts.snap
@@ -3,13 +3,6 @@
 exports[`contentWithNoImports - Manifest V2 1`] = `
 [
   {
-    "fileName": "test/manifest/resources/contentWithNoImports/content.js",
-    "name": undefined,
-    "source": "console.log(\\"content\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -28,6 +21,13 @@ exports[`contentWithNoImports - Manifest V2 1`] = `
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithNoImports/content.js",
+    "name": undefined,
+    "source": "console.log(\\"content\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/contentWithNoImports.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/contentWithNoImports.v3.test.ts.snap
@@ -3,13 +3,6 @@
 exports[`contentWithNoImports - Manifest V3 1`] = `
 [
   {
-    "fileName": "test/manifest/resources/contentWithNoImports/content.js",
-    "name": undefined,
-    "source": "console.log(\\"content\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -32,6 +25,13 @@ exports[`contentWithNoImports - Manifest V3 1`] = `
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithNoImports/content.js",
+    "name": undefined,
+    "source": "console.log(\\"content\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/contentWithSameScriptName.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/contentWithSameScriptName.v2.test.ts.snap
@@ -3,20 +3,6 @@
 exports[`contentWithSameScriptName - Manifest V2 1`] = `
 [
   {
-    "fileName": "test/manifest/resources/contentWithSameScriptName/content1/content.js",
-    "name": undefined,
-    "source": "console.log(\\"content1\\");
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/contentWithSameScriptName/content2/content.js",
-    "name": undefined,
-    "source": "console.log(\\"content2\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -44,6 +30,20 @@ exports[`contentWithSameScriptName - Manifest V2 1`] = `
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithSameScriptName/content1/content.js",
+    "name": undefined,
+    "source": "console.log(\\"content1\\");
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithSameScriptName/content2/content.js",
+    "name": undefined,
+    "source": "console.log(\\"content2\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/contentWithSameScriptName.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/contentWithSameScriptName.v3.test.ts.snap
@@ -3,20 +3,6 @@
 exports[`contentWithSameScriptName - Manifest V3 1`] = `
 [
   {
-    "fileName": "test/manifest/resources/contentWithSameScriptName/content1/content.js",
-    "name": undefined,
-    "source": "console.log(\\"content1\\");
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/contentWithSameScriptName/content2/content.js",
-    "name": undefined,
-    "source": "console.log(\\"content2\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -52,6 +38,20 @@ exports[`contentWithSameScriptName - Manifest V3 1`] = `
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithSameScriptName/content1/content.js",
+    "name": undefined,
+    "source": "console.log(\\"content1\\");
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithSameScriptName/content2/content.js",
+    "name": undefined,
+    "source": "console.log(\\"content2\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/contentWithUnchunkedImport.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/contentWithUnchunkedImport.v2.test.ts.snap
@@ -3,16 +3,6 @@
 exports[`contentWithUnchunkedImport - Manifest V2 1`] = `
 [
   {
-    "fileName": "test/manifest/resources/contentWithUnchunkedImport/content.js",
-    "name": undefined,
-    "source": "function log(message) {
-  console.log(message);
-}
-log(\\"content\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -31,6 +21,16 @@ log(\\"content\\");
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithUnchunkedImport/content.js",
+    "name": undefined,
+    "source": "function log(message) {
+  console.log(message);
+}
+log(\\"content\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/contentWithUnchunkedImport.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/contentWithUnchunkedImport.v3.test.ts.snap
@@ -3,16 +3,6 @@
 exports[`contentWithUnchunkedImport - Manifest V3 1`] = `
 [
   {
-    "fileName": "test/manifest/resources/contentWithUnchunkedImport/content.js",
-    "name": undefined,
-    "source": "function log(message) {
-  console.log(message);
-}
-log(\\"content\\");
-",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -35,6 +25,16 @@ log(\\"content\\");
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/contentWithUnchunkedImport/content.js",
+    "name": undefined,
+    "source": "function log(message) {
+  console.log(message);
+}
+log(\\"content\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/devtoolsHtml.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/devtoolsHtml.v2.test.ts.snap
@@ -55,6 +55,17 @@ log(\\"devtools\\");
     },
   },
   {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 2,
+  \\"devtools_page\\": \\"test/manifest/resources/devtoolsHtml/devtools.html\\"
+}",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/devtoolsHtml/devtools.html",
     "name": undefined,
     "source": "<!DOCTYPE html>
@@ -68,17 +79,6 @@ log(\\"devtools\\");
   </head>
 </html>
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 2,
-  \\"devtools_page\\": \\"test/manifest/resources/devtoolsHtml/devtools.html\\"
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/devtoolsHtml.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/devtoolsHtml.v3.test.ts.snap
@@ -55,6 +55,17 @@ log(\\"devtools\\");
     },
   },
   {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 3,
+  \\"devtools_page\\": \\"test/manifest/resources/devtoolsHtml/devtools.html\\"
+}",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/devtoolsHtml/devtools.html",
     "name": undefined,
     "source": "<!DOCTYPE html>
@@ -68,17 +79,6 @@ log(\\"devtools\\");
   </head>
 </html>
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 3,
-  \\"devtools_page\\": \\"test/manifest/resources/devtoolsHtml/devtools.html\\"
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/fullExtension.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/fullExtension.v2.test.ts.snap
@@ -3,160 +3,6 @@
 exports[`fullExtension - Manifest V2 1`] = `
 [
   {
-    "code": "import { l as logo } from \\"../../../../../../../logo.js\\";
-const style = \\"\\";
-const imageUrl = new URL(logo, import.meta.url).href;
-document.querySelector(\\"#app\\").innerHTML = \`
-  <img src=\\"\${imageUrl}\\" height=\\"45\\" alt=\\"\\" />
-  <h1>Options</h1>
-  <a href=\\"https://vitejs.dev/guide/features.html\\" target=\\"_blank\\">Vite Docs</a>
-\`;
-",
-    "dynamicImports": [],
-    "exports": [],
-    "facadeModuleId": "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/options/index.html",
-    "fileName": "assets/test/manifest/resources/fullExtension/src/entries/options/index.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {
-      "assets/logo.js": [
-        "l",
-      ],
-    },
-    "imports": [
-      "assets/logo.js",
-    ],
-    "isDynamicEntry": false,
-    "isEntry": true,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/options/index.html": {
-        "code": null,
-        "originalLength": 212,
-        "removedExports": [],
-        "renderedExports": [],
-        "renderedLength": 0,
-      },
-      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/options/main.js": {
-        "code": "const imageUrl = new URL(logo, import.meta.url).href;
-
-document.querySelector(\\"#app\\").innerHTML = \`
-  <img src=\\"\${imageUrl}\\" height=\\"45\\" alt=\\"\\" />
-  <h1>Options</h1>
-  <a href=\\"https://vitejs.dev/guide/features.html\\" target=\\"_blank\\">Vite Docs</a>
-\`;",
-        "originalLength": 315,
-        "removedExports": [],
-        "renderedExports": [],
-        "renderedLength": 249,
-      },
-      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/options/style.css": {
-        "code": "const style = '';",
-        "originalLength": 202,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 17,
-      },
-    },
-    "name": "test/manifest/resources/fullExtension/src/entries/options/index",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {
-        "assets/index.css",
-      },
-    },
-  },
-  {
-    "code": "import { l as logo } from \\"../../../../../../../../logo.js\\";
-async function renderContent(cssPaths, render = (_appRoot) => {
-}) {
-  console.log(\\"renderContent\\", cssPaths);
-}
-const style = \\"\\";
-renderContent([\\"assets/main.css\\"], (appRoot) => {
-  const logoImageUrl = new URL(logo, import.meta.url).href;
-  appRoot.innerHTML = \`
-    <div class=\\"logo\\">
-      <img src=\\"\${logoImageUrl}\\" height=\\"50\\" alt=\\"\\" />
-    </div>
-  \`;
-});
-console.log(chrome.runtime.getURL(\\"src/lib.js\\"));
-",
-    "dynamicImports": [],
-    "exports": [],
-    "facadeModuleId": "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js",
-    "fileName": "assets/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {
-      "assets/logo.js": [
-        "l",
-      ],
-    },
-    "imports": [
-      "assets/logo.js",
-    ],
-    "isDynamicEntry": false,
-    "isEntry": true,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js": {
-        "code": "renderContent(import.meta.PLUGIN_WEB_EXT_CHUNK_CSS_PATHS, (appRoot) => {
-  const logoImageUrl = new URL(logo, import.meta.url).href;
-
-  appRoot.innerHTML = \`
-    <div class=\\"logo\\">
-      <img src=\\"\${logoImageUrl}\\" height=\\"50\\" alt=\\"\\" />
-    </div>
-  \`;
-});
-
-console.log(chrome.runtime.getURL(\\"src/lib.js\\"));",
-        "originalLength": 421,
-        "removedExports": [],
-        "renderedExports": [],
-        "renderedLength": 306,
-      },
-      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/contentScript/primary/style.css": {
-        "code": "const style = '';",
-        "originalLength": 296,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 17,
-      },
-      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/contentScript/renderContent.js": {
-        "code": "async function renderContent(
-  cssPaths,
-  render = (_appRoot) => {}
-) {
-  console.log(\\"renderContent\\", cssPaths);
-}",
-        "originalLength": 133,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 117,
-      },
-    },
-    "name": "test/manifest/resources/fullExtension/src/entries/contentScript/primary/main",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {
-        "assets/main.css",
-      },
-    },
-  },
-  {
     "code": "browser.runtime.onInstalled.addListener(() => {
   console.log(\\"Extension installed\\");
 });
@@ -224,6 +70,23 @@ async function getCurrentTab() {
       "importedAssets": Set {},
       "importedCss": Set {},
     },
+  },
+  {
+    "fileName": "assets/index.css",
+    "name": "index.css",
+    "source": "#app {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: center;
+  color: #2c3e50;
+}
+
+h1 {
+  margin: 5px;
+}
+",
+    "type": "asset",
   },
   {
     "code": "const logo = \\"/assets/logo.svg\\";
@@ -3294,23 +3157,6 @@ export {
     "type": "asset",
   },
   {
-    "fileName": "assets/index.css",
-    "name": "index.css",
-    "source": "#app {
-  font-family: Avenir, Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-align: center;
-  color: #2c3e50;
-}
-
-h1 {
-  margin: 5px;
-}
-",
-    "type": "asset",
-  },
-  {
     "fileName": "assets/main.css",
     "name": "main.css",
     "source": ".logo {
@@ -3336,42 +3182,164 @@ img {
     "type": "asset",
   },
   {
+    "code": "import { l as logo } from \\"../../../../../../../../logo.js\\";
+async function renderContent(cssPaths, render = (_appRoot) => {
+}) {
+  console.log(\\"renderContent\\", cssPaths);
+}
+const style = \\"\\";
+renderContent([\\"assets/main.css\\"], (appRoot) => {
+  const logoImageUrl = new URL(logo, import.meta.url).href;
+  appRoot.innerHTML = \`
+    <div class=\\"logo\\">
+      <img src=\\"\${logoImageUrl}\\" height=\\"50\\" alt=\\"\\" />
+    </div>
+  \`;
+});
+console.log(chrome.runtime.getURL(\\"src/lib.js\\"));
+",
+    "dynamicImports": [],
+    "exports": [],
+    "facadeModuleId": "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js",
+    "fileName": "assets/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {
+      "assets/logo.js": [
+        "l",
+      ],
+    },
+    "imports": [
+      "assets/logo.js",
+    ],
+    "isDynamicEntry": false,
+    "isEntry": true,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js": {
+        "code": "renderContent(import.meta.PLUGIN_WEB_EXT_CHUNK_CSS_PATHS, (appRoot) => {
+  const logoImageUrl = new URL(logo, import.meta.url).href;
+
+  appRoot.innerHTML = \`
+    <div class=\\"logo\\">
+      <img src=\\"\${logoImageUrl}\\" height=\\"50\\" alt=\\"\\" />
+    </div>
+  \`;
+});
+
+console.log(chrome.runtime.getURL(\\"src/lib.js\\"));",
+        "originalLength": 421,
+        "removedExports": [],
+        "renderedExports": [],
+        "renderedLength": 306,
+      },
+      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/contentScript/primary/style.css": {
+        "code": "const style = '';",
+        "originalLength": 296,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 17,
+      },
+      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/contentScript/renderContent.js": {
+        "code": "async function renderContent(
+  cssPaths,
+  render = (_appRoot) => {}
+) {
+  console.log(\\"renderContent\\", cssPaths);
+}",
+        "originalLength": 133,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 117,
+      },
+    },
+    "name": "test/manifest/resources/fullExtension/src/entries/contentScript/primary/main",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {
+        "assets/main.css",
+      },
+    },
+  },
+  {
+    "code": "import { l as logo } from \\"../../../../../../../logo.js\\";
+const style = \\"\\";
+const imageUrl = new URL(logo, import.meta.url).href;
+document.querySelector(\\"#app\\").innerHTML = \`
+  <img src=\\"\${imageUrl}\\" height=\\"45\\" alt=\\"\\" />
+  <h1>Options</h1>
+  <a href=\\"https://vitejs.dev/guide/features.html\\" target=\\"_blank\\">Vite Docs</a>
+\`;
+",
+    "dynamicImports": [],
+    "exports": [],
+    "facadeModuleId": "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/options/index.html",
+    "fileName": "assets/test/manifest/resources/fullExtension/src/entries/options/index.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {
+      "assets/logo.js": [
+        "l",
+      ],
+    },
+    "imports": [
+      "assets/logo.js",
+    ],
+    "isDynamicEntry": false,
+    "isEntry": true,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/options/index.html": {
+        "code": null,
+        "originalLength": 212,
+        "removedExports": [],
+        "renderedExports": [],
+        "renderedLength": 0,
+      },
+      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/options/main.js": {
+        "code": "const imageUrl = new URL(logo, import.meta.url).href;
+
+document.querySelector(\\"#app\\").innerHTML = \`
+  <img src=\\"\${imageUrl}\\" height=\\"45\\" alt=\\"\\" />
+  <h1>Options</h1>
+  <a href=\\"https://vitejs.dev/guide/features.html\\" target=\\"_blank\\">Vite Docs</a>
+\`;",
+        "originalLength": 315,
+        "removedExports": [],
+        "renderedExports": [],
+        "renderedLength": 249,
+      },
+      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/options/style.css": {
+        "code": "const style = '';",
+        "originalLength": 202,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 17,
+      },
+    },
+    "name": "test/manifest/resources/fullExtension/src/entries/options/index",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {
+        "assets/index.css",
+      },
+    },
+  },
+  {
     "fileName": "background.html",
     "name": undefined,
     "source": "<!DOCTYPE html><html lang=\\"en\\"><head><meta charset=\\"UTF-8\\" />  <script type=\\"module\\" crossorigin src=\\"/assets/background.js\\"></script>
 </head></html>",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/fullExtension/src/entries/options/index.html",
-    "name": undefined,
-    "source": "<!DOCTYPE html>
-<html lang=\\"en\\">
-  <head>
-    <meta charset=\\"UTF-8\\" />
-    <title>Options</title>
-    <script type=\\"module\\" crossorigin src=\\"/assets/test/manifest/resources/fullExtension/src/entries/options/index.js\\"></script>
-    <link rel=\\"stylesheet\\" href=\\"/assets/index.css\\">
-  </head>
-  <body>
-    <div id=\\"app\\"></div>
-    
-  </body>
-</html>
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/fullExtension/src/lib.js",
-    "name": undefined,
-    "source": "console.log(\\"lib.js\\");
-",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js\\"))})();",
     "type": "asset",
   },
   {
@@ -3416,6 +3384,38 @@ img {
     \\"test/manifest/resources/fullExtension/src/lib.js\\"
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/fullExtension/src/entries/options/index.html",
+    "name": undefined,
+    "source": "<!DOCTYPE html>
+<html lang=\\"en\\">
+  <head>
+    <meta charset=\\"UTF-8\\" />
+    <title>Options</title>
+    <script type=\\"module\\" crossorigin src=\\"/assets/test/manifest/resources/fullExtension/src/entries/options/index.js\\"></script>
+    <link rel=\\"stylesheet\\" href=\\"/assets/index.css\\">
+  </head>
+  <body>
+    <div id=\\"app\\"></div>
+    
+  </body>
+</html>
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/fullExtension/src/lib.js",
+    "name": undefined,
+    "source": "console.log(\\"lib.js\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/fullExtension.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/fullExtension.v3.test.ts.snap
@@ -3,220 +3,21 @@
 exports[`fullExtension - Manifest V3 1`] = `
 [
   {
-    "code": "import { l as logo } from \\"../../../../../../../logo.js\\";
-const style = \\"\\";
-const imageUrl = new URL(logo, import.meta.url).href;
-document.querySelector(\\"#app\\").innerHTML = \`
-  <img src=\\"\${imageUrl}\\" height=\\"45\\" alt=\\"\\" />
-  <h1>Options</h1>
-  <a href=\\"https://vitejs.dev/guide/features.html\\" target=\\"_blank\\">Vite Docs</a>
-\`;
-",
-    "dynamicImports": [],
-    "exports": [],
-    "facadeModuleId": "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/options/index.html",
-    "fileName": "assets/test/manifest/resources/fullExtension/src/entries/options/index.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {
-      "assets/logo.js": [
-        "l",
-      ],
-    },
-    "imports": [
-      "assets/logo.js",
-    ],
-    "isDynamicEntry": false,
-    "isEntry": true,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/options/index.html": {
-        "code": null,
-        "originalLength": 212,
-        "removedExports": [],
-        "renderedExports": [],
-        "renderedLength": 0,
-      },
-      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/options/main.js": {
-        "code": "const imageUrl = new URL(logo, import.meta.url).href;
-
-document.querySelector(\\"#app\\").innerHTML = \`
-  <img src=\\"\${imageUrl}\\" height=\\"45\\" alt=\\"\\" />
-  <h1>Options</h1>
-  <a href=\\"https://vitejs.dev/guide/features.html\\" target=\\"_blank\\">Vite Docs</a>
-\`;",
-        "originalLength": 315,
-        "removedExports": [],
-        "renderedExports": [],
-        "renderedLength": 249,
-      },
-      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/options/style.css": {
-        "code": "const style = '';",
-        "originalLength": 202,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 17,
-      },
-    },
-    "name": "test/manifest/resources/fullExtension/src/entries/options/index",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {
-        "assets/index.css",
-      },
-    },
-  },
-  {
-    "code": "import { l as logo } from \\"../../../../../../../../logo.js\\";
-async function renderContent(cssPaths, render = (_appRoot) => {
-}) {
-  console.log(\\"renderContent\\", cssPaths);
+    "fileName": "assets/index.css",
+    "name": "index.css",
+    "source": "#app {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: center;
+  color: #2c3e50;
 }
-const style = \\"\\";
-renderContent([\\"assets/main.css\\"], (appRoot) => {
-  const logoImageUrl = new URL(logo, import.meta.url).href;
-  appRoot.innerHTML = \`
-    <div class=\\"logo\\">
-      <img src=\\"\${logoImageUrl}\\" height=\\"50\\" alt=\\"\\" />
-    </div>
-  \`;
-});
-console.log(chrome.runtime.getURL(\\"src/lib.js\\"));
-",
-    "dynamicImports": [],
-    "exports": [],
-    "facadeModuleId": "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js",
-    "fileName": "assets/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {
-      "assets/logo.js": [
-        "l",
-      ],
-    },
-    "imports": [
-      "assets/logo.js",
-    ],
-    "isDynamicEntry": false,
-    "isEntry": true,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js": {
-        "code": "renderContent(import.meta.PLUGIN_WEB_EXT_CHUNK_CSS_PATHS, (appRoot) => {
-  const logoImageUrl = new URL(logo, import.meta.url).href;
 
-  appRoot.innerHTML = \`
-    <div class=\\"logo\\">
-      <img src=\\"\${logoImageUrl}\\" height=\\"50\\" alt=\\"\\" />
-    </div>
-  \`;
-});
-
-console.log(chrome.runtime.getURL(\\"src/lib.js\\"));",
-        "originalLength": 421,
-        "removedExports": [],
-        "renderedExports": [],
-        "renderedLength": 306,
-      },
-      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/contentScript/primary/style.css": {
-        "code": "const style = '';",
-        "originalLength": 296,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 17,
-      },
-      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/contentScript/renderContent.js": {
-        "code": "async function renderContent(
-  cssPaths,
-  render = (_appRoot) => {}
-) {
-  console.log(\\"renderContent\\", cssPaths);
-}",
-        "originalLength": 133,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 117,
-      },
-    },
-    "name": "test/manifest/resources/fullExtension/src/entries/contentScript/primary/main",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {
-        "assets/main.css",
-      },
-    },
-  },
-  {
-    "code": "browser.runtime.onInstalled.addListener(() => {
-  console.log(\\"Extension installed\\");
-});
-browser.action.onClicked.addListener(async () => {
-  const tab = await getCurrentTab();
-  chrome.scripting.executeScript({
-    target: { tabId: tab?.id },
-    files: [\\"src/lib.js\\"]
-  });
-});
-async function getCurrentTab() {
-  let queryOptions = { active: true, lastFocusedWindow: true };
-  let [tab] = await chrome.tabs.query(queryOptions);
-  return tab;
+h1 {
+  margin: 5px;
 }
 ",
-    "dynamicImports": [],
-    "exports": [],
-    "facadeModuleId": "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/background/main.js",
-    "fileName": "assets/test/manifest/resources/fullExtension/src/entries/background/main.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": true,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/background/main.js": {
-        "code": "browser.runtime.onInstalled.addListener(() => {
-  console.log(\\"Extension installed\\");
-});
-
-browser.action.onClicked.addListener(async () => {
-  const tab = await getCurrentTab();
-
-  chrome.scripting.executeScript({
-    target: { tabId: tab?.id },
-    files: [\\"src/lib.js\\"],
-  });
-});
-
-async function getCurrentTab() {
-  let queryOptions = { active: true, lastFocusedWindow: true };
-  let [tab] = await chrome.tabs.query(queryOptions);
-  return tab;
-}",
-        "originalLength": 451,
-        "removedExports": [],
-        "renderedExports": [],
-        "renderedLength": 450,
-      },
-    },
-    "name": "test/manifest/resources/fullExtension/src/entries/background/main",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
+    "type": "asset",
   },
   {
     "code": "const logo = \\"/assets/logo.svg\\";
@@ -3287,23 +3088,6 @@ export {
     "type": "asset",
   },
   {
-    "fileName": "assets/index.css",
-    "name": "index.css",
-    "source": "#app {
-  font-family: Avenir, Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-align: center;
-  color: #2c3e50;
-}
-
-h1 {
-  margin: 5px;
-}
-",
-    "type": "asset",
-  },
-  {
     "fileName": "assets/main.css",
     "name": "main.css",
     "source": ".logo {
@@ -3329,42 +3113,220 @@ img {
     "type": "asset",
   },
   {
-    "fileName": "test/manifest/resources/fullExtension/src/entries/options/index.html",
-    "name": undefined,
-    "source": "<!DOCTYPE html>
-<html lang=\\"en\\">
-  <head>
-    <meta charset=\\"UTF-8\\" />
-    <title>Options</title>
-    <script type=\\"module\\" crossorigin src=\\"/assets/test/manifest/resources/fullExtension/src/entries/options/index.js\\"></script>
-    <link rel=\\"stylesheet\\" href=\\"/assets/index.css\\">
-  </head>
-  <body>
-    <div id=\\"app\\"></div>
-    
-  </body>
-</html>
+    "code": "browser.runtime.onInstalled.addListener(() => {
+  console.log(\\"Extension installed\\");
+});
+browser.action.onClicked.addListener(async () => {
+  const tab = await getCurrentTab();
+  chrome.scripting.executeScript({
+    target: { tabId: tab?.id },
+    files: [\\"src/lib.js\\"]
+  });
+});
+async function getCurrentTab() {
+  let queryOptions = { active: true, lastFocusedWindow: true };
+  let [tab] = await chrome.tabs.query(queryOptions);
+  return tab;
+}
 ",
-    "type": "asset",
+    "dynamicImports": [],
+    "exports": [],
+    "facadeModuleId": "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/background/main.js",
+    "fileName": "assets/test/manifest/resources/fullExtension/src/entries/background/main.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": true,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/background/main.js": {
+        "code": "browser.runtime.onInstalled.addListener(() => {
+  console.log(\\"Extension installed\\");
+});
+
+browser.action.onClicked.addListener(async () => {
+  const tab = await getCurrentTab();
+
+  chrome.scripting.executeScript({
+    target: { tabId: tab?.id },
+    files: [\\"src/lib.js\\"],
+  });
+});
+
+async function getCurrentTab() {
+  let queryOptions = { active: true, lastFocusedWindow: true };
+  let [tab] = await chrome.tabs.query(queryOptions);
+  return tab;
+}",
+        "originalLength": 451,
+        "removedExports": [],
+        "renderedExports": [],
+        "renderedLength": 450,
+      },
+    },
+    "name": "test/manifest/resources/fullExtension/src/entries/background/main",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
   },
   {
-    "fileName": "test/manifest/resources/fullExtension/src/lib.js",
-    "name": undefined,
-    "source": "console.log(\\"lib.js\\");
+    "code": "import { l as logo } from \\"../../../../../../../../logo.js\\";
+async function renderContent(cssPaths, render = (_appRoot) => {
+}) {
+  console.log(\\"renderContent\\", cssPaths);
+}
+const style = \\"\\";
+renderContent([\\"assets/main.css\\"], (appRoot) => {
+  const logoImageUrl = new URL(logo, import.meta.url).href;
+  appRoot.innerHTML = \`
+    <div class=\\"logo\\">
+      <img src=\\"\${logoImageUrl}\\" height=\\"50\\" alt=\\"\\" />
+    </div>
+  \`;
+});
+console.log(chrome.runtime.getURL(\\"src/lib.js\\"));
 ",
-    "type": "asset",
+    "dynamicImports": [],
+    "exports": [],
+    "facadeModuleId": "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js",
+    "fileName": "assets/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {
+      "assets/logo.js": [
+        "l",
+      ],
+    },
+    "imports": [
+      "assets/logo.js",
+    ],
+    "isDynamicEntry": false,
+    "isEntry": true,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js": {
+        "code": "renderContent(import.meta.PLUGIN_WEB_EXT_CHUNK_CSS_PATHS, (appRoot) => {
+  const logoImageUrl = new URL(logo, import.meta.url).href;
+
+  appRoot.innerHTML = \`
+    <div class=\\"logo\\">
+      <img src=\\"\${logoImageUrl}\\" height=\\"50\\" alt=\\"\\" />
+    </div>
+  \`;
+});
+
+console.log(chrome.runtime.getURL(\\"src/lib.js\\"));",
+        "originalLength": 421,
+        "removedExports": [],
+        "renderedExports": [],
+        "renderedLength": 306,
+      },
+      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/contentScript/primary/style.css": {
+        "code": "const style = '';",
+        "originalLength": 296,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 17,
+      },
+      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/contentScript/renderContent.js": {
+        "code": "async function renderContent(
+  cssPaths,
+  render = (_appRoot) => {}
+) {
+  console.log(\\"renderContent\\", cssPaths);
+}",
+        "originalLength": 133,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 117,
+      },
+    },
+    "name": "test/manifest/resources/fullExtension/src/entries/contentScript/primary/main",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {
+        "assets/main.css",
+      },
+    },
   },
   {
-    "fileName": "test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "serviceWorker.js",
-    "name": undefined,
-    "source": "import \\"/assets/test/manifest/resources/fullExtension/src/entries/background/main.js\\";",
-    "type": "asset",
+    "code": "import { l as logo } from \\"../../../../../../../logo.js\\";
+const style = \\"\\";
+const imageUrl = new URL(logo, import.meta.url).href;
+document.querySelector(\\"#app\\").innerHTML = \`
+  <img src=\\"\${imageUrl}\\" height=\\"45\\" alt=\\"\\" />
+  <h1>Options</h1>
+  <a href=\\"https://vitejs.dev/guide/features.html\\" target=\\"_blank\\">Vite Docs</a>
+\`;
+",
+    "dynamicImports": [],
+    "exports": [],
+    "facadeModuleId": "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/options/index.html",
+    "fileName": "assets/test/manifest/resources/fullExtension/src/entries/options/index.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {
+      "assets/logo.js": [
+        "l",
+      ],
+    },
+    "imports": [
+      "assets/logo.js",
+    ],
+    "isDynamicEntry": false,
+    "isEntry": true,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/options/index.html": {
+        "code": null,
+        "originalLength": 212,
+        "removedExports": [],
+        "renderedExports": [],
+        "renderedLength": 0,
+      },
+      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/options/main.js": {
+        "code": "const imageUrl = new URL(logo, import.meta.url).href;
+
+document.querySelector(\\"#app\\").innerHTML = \`
+  <img src=\\"\${imageUrl}\\" height=\\"45\\" alt=\\"\\" />
+  <h1>Options</h1>
+  <a href=\\"https://vitejs.dev/guide/features.html\\" target=\\"_blank\\">Vite Docs</a>
+\`;",
+        "originalLength": 315,
+        "removedExports": [],
+        "renderedExports": [],
+        "renderedLength": 249,
+      },
+      "vite-plugin-web-extension/test/manifest/resources/fullExtension/src/entries/options/style.css": {
+        "code": "const style = '';",
+        "originalLength": 202,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 17,
+      },
+    },
+    "name": "test/manifest/resources/fullExtension/src/entries/options/index",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {
+        "assets/index.css",
+      },
+    },
   },
   {
     "fileName": "manifest.json",
@@ -3430,6 +3392,44 @@ img {
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "serviceWorker.js",
+    "name": undefined,
+    "source": "import \\"/assets/test/manifest/resources/fullExtension/src/entries/background/main.js\\";",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/fullExtension/src/entries/contentScript/primary/main.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/fullExtension/src/entries/options/index.html",
+    "name": undefined,
+    "source": "<!DOCTYPE html>
+<html lang=\\"en\\">
+  <head>
+    <meta charset=\\"UTF-8\\" />
+    <title>Options</title>
+    <script type=\\"module\\" crossorigin src=\\"/assets/test/manifest/resources/fullExtension/src/entries/options/index.js\\"></script>
+    <link rel=\\"stylesheet\\" href=\\"/assets/index.css\\">
+  </head>
+  <body>
+    <div id=\\"app\\"></div>
+    
+  </body>
+</html>
+",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/fullExtension/src/lib.js",
+    "name": undefined,
+    "source": "console.log(\\"lib.js\\");
+",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/optimizeWebAccessibleResourcesDisabled.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/optimizeWebAccessibleResourcesDisabled.v2.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`optimizeWebAccessibleResourcesDisabled - Manifest V2 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as l
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "l",
+    ],
+    "facadeModuleId": null,
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "import { l as log } from \\"../../../../log.js\\";
 log(\\"content\\");
 ",
@@ -155,72 +197,6 @@ log(\\"script2\\");
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as l
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "l",
-    ],
-    "facadeModuleId": null,
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
-}",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
-  },
-  {
-    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/script1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/script1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/script2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/script2.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/content1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/content1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/content2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/content2.js\\"))})();",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -255,6 +231,30 @@ export {
     \\"assets/test/manifest/resources/optimizeWebAccessibleResources/content2.js\\"
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/content1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/content1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/content2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/content2.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/script1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/script1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/script2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/script2.js\\"))})();",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/optimizeWebAccessibleResourcesDisabled.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/optimizeWebAccessibleResourcesDisabled.v3.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`optimizeWebAccessibleResourcesDisabled - Manifest V3 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as l
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "l",
+    ],
+    "facadeModuleId": null,
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "import { l as log } from \\"../../../../log.js\\";
 log(\\"content\\");
 ",
@@ -155,72 +197,6 @@ log(\\"script2\\");
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as l
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "l",
-    ],
-    "facadeModuleId": null,
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
-}",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
-  },
-  {
-    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/script1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/script1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/script2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/script2.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/content1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/content1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/content2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/content2.js\\"))})();",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -290,6 +266,30 @@ export {
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/content1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/content1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/content2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/content2.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/script1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/script1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/script2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/script2.js\\"))})();",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/optimizeWebAccessibleResourcesEnabled.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/optimizeWebAccessibleResourcesEnabled.v2.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`optimizeWebAccessibleResourcesEnabled - Manifest V2 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as l
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "l",
+    ],
+    "facadeModuleId": null,
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "import { l as log } from \\"../../../../log.js\\";
 log(\\"content\\");
 ",
@@ -155,72 +197,6 @@ log(\\"script2\\");
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as l
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "l",
-    ],
-    "facadeModuleId": null,
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
-}",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
-  },
-  {
-    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/script1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/script1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/script2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/script2.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/content1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/content1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/content2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/content2.js\\"))})();",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -255,6 +231,30 @@ export {
     \\"test/manifest/resources/optimizeWebAccessibleResources/script2.js\\"
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/content1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/content1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/content2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/content2.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/script1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/script1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/script2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/script2.js\\"))})();",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/optimizeWebAccessibleResourcesEnabled.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/optimizeWebAccessibleResourcesEnabled.v3.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`optimizeWebAccessibleResourcesEnabled - Manifest V3 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as l
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "l",
+    ],
+    "facadeModuleId": null,
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "import { l as log } from \\"../../../../log.js\\";
 log(\\"content\\");
 ",
@@ -155,72 +197,6 @@ log(\\"script2\\");
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as l
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "l",
-    ],
-    "facadeModuleId": null,
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
-}",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
-  },
-  {
-    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/script1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/script1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/script2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/script2.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/content1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/content1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/content2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/content2.js\\"))})();",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -263,6 +239,30 @@ export {
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/content1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/content1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/content2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/content2.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/script1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/script1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/optimizeWebAccessibleResources/script2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/optimizeWebAccessibleResources/script2.js\\"))})();",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/optionsHtml.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/optionsHtml.v2.test.ts.snap
@@ -55,6 +55,19 @@ log(\\"options\\");
     },
   },
   {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 2,
+  \\"options_ui\\": {
+    \\"page\\": \\"test/manifest/resources/optionsHtml/options.html\\"
+  }
+}",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/optionsHtml/options.html",
     "name": undefined,
     "source": "<!DOCTYPE html>
@@ -68,19 +81,6 @@ log(\\"options\\");
   </head>
 </html>
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 2,
-  \\"options_ui\\": {
-    \\"page\\": \\"test/manifest/resources/optionsHtml/options.html\\"
-  }
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/optionsHtml.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/optionsHtml.v3.test.ts.snap
@@ -55,6 +55,19 @@ log(\\"options\\");
     },
   },
   {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 3,
+  \\"options_ui\\": {
+    \\"page\\": \\"test/manifest/resources/optionsHtml/options.html\\"
+  }
+}",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/optionsHtml/options.html",
     "name": undefined,
     "source": "<!DOCTYPE html>
@@ -68,19 +81,6 @@ log(\\"options\\");
   </head>
 </html>
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 3,
-  \\"options_ui\\": {
-    \\"page\\": \\"test/manifest/resources/optionsHtml/options.html\\"
-  }
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/popupHtml.v2.test.ts.snap
+++ b/test/manifest/__snapshots__/popupHtml.v2.test.ts.snap
@@ -55,6 +55,19 @@ log(\\"popup\\");
     },
   },
   {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 2,
+  \\"browser_action\\": {
+    \\"default_popup\\": \\"test/manifest/resources/popupHtml/popup.html\\"
+  }
+}",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/popupHtml/popup.html",
     "name": undefined,
     "source": "<!DOCTYPE html>
@@ -68,19 +81,6 @@ log(\\"popup\\");
   </head>
 </html>
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 2,
-  \\"browser_action\\": {
-    \\"default_popup\\": \\"test/manifest/resources/popupHtml/popup.html\\"
-  }
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/popupHtml.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/popupHtml.v3.test.ts.snap
@@ -55,6 +55,19 @@ log(\\"popup\\");
     },
   },
   {
+    "fileName": "manifest.json",
+    "name": undefined,
+    "source": "{
+  \\"version\\": \\"1.0.0\\",
+  \\"name\\": \\"Manifest Name\\",
+  \\"manifest_version\\": 3,
+  \\"action\\": {
+    \\"default_popup\\": \\"test/manifest/resources/popupHtml/popup.html\\"
+  }
+}",
+    "type": "asset",
+  },
+  {
     "fileName": "test/manifest/resources/popupHtml/popup.html",
     "name": undefined,
     "source": "<!DOCTYPE html>
@@ -68,19 +81,6 @@ log(\\"popup\\");
   </head>
 </html>
 ",
-    "type": "asset",
-  },
-  {
-    "fileName": "manifest.json",
-    "name": undefined,
-    "source": "{
-  \\"version\\": \\"1.0.0\\",
-  \\"name\\": \\"Manifest Name\\",
-  \\"manifest_version\\": 3,
-  \\"action\\": {
-    \\"default_popup\\": \\"test/manifest/resources/popupHtml/popup.html\\"
-  }
-}",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/useDynamicUrlWebAccessibleResourcesDisabled.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/useDynamicUrlWebAccessibleResourcesDisabled.v3.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`useDynamicUrlWebAccessibleResourcesDisabled - Manifest V3 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as l
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "l",
+    ],
+    "facadeModuleId": null,
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "import { l as log } from \\"../../../../log.js\\";
 log(\\"content\\");
 ",
@@ -155,72 +197,6 @@ log(\\"script2\\");
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as l
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "l",
-    ],
-    "facadeModuleId": null,
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
-}",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
-  },
-  {
-    "fileName": "test/manifest/resources/useDynamicUrlWebAccessibleResources/script1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/useDynamicUrlWebAccessibleResources/script1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/useDynamicUrlWebAccessibleResources/script2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/useDynamicUrlWebAccessibleResources/script2.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/useDynamicUrlWebAccessibleResources/content1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/useDynamicUrlWebAccessibleResources/content1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/useDynamicUrlWebAccessibleResources/content2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/useDynamicUrlWebAccessibleResources/content2.js\\"))})();",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -262,6 +238,30 @@ export {
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/useDynamicUrlWebAccessibleResources/content1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/useDynamicUrlWebAccessibleResources/content1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/useDynamicUrlWebAccessibleResources/content2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/useDynamicUrlWebAccessibleResources/content2.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/useDynamicUrlWebAccessibleResources/script1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/useDynamicUrlWebAccessibleResources/script1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/useDynamicUrlWebAccessibleResources/script2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/useDynamicUrlWebAccessibleResources/script2.js\\"))})();",
     "type": "asset",
   },
 ]

--- a/test/manifest/__snapshots__/useDynamicUrlWebAccessibleResourcesEnabled.v3.test.ts.snap
+++ b/test/manifest/__snapshots__/useDynamicUrlWebAccessibleResourcesEnabled.v3.test.ts.snap
@@ -3,6 +3,48 @@
 exports[`useDynamicUrlWebAccessibleResourcesEnabled - Manifest V3 1`] = `
 [
   {
+    "code": "function log(message) {
+  console.log(message);
+}
+export {
+  log as l
+};
+",
+    "dynamicImports": [],
+    "exports": [
+      "l",
+    ],
+    "facadeModuleId": null,
+    "fileName": "assets/log.js",
+    "implicitlyLoadedBefore": [],
+    "importedBindings": {},
+    "imports": [],
+    "isDynamicEntry": false,
+    "isEntry": false,
+    "isImplicitEntry": false,
+    "map": null,
+    "modules": {
+      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
+        "code": "function log(message) {
+  console.log(message);
+}",
+        "originalLength": 65,
+        "removedExports": [],
+        "renderedExports": [
+          "default",
+        ],
+        "renderedLength": 49,
+      },
+    },
+    "name": "log",
+    "referencedFiles": [],
+    "type": "chunk",
+    "viteMetadata": {
+      "importedAssets": Set {},
+      "importedCss": Set {},
+    },
+  },
+  {
     "code": "import { l as log } from \\"../../../../log.js\\";
 log(\\"content\\");
 ",
@@ -155,72 +197,6 @@ log(\\"script2\\");
     },
   },
   {
-    "code": "function log(message) {
-  console.log(message);
-}
-export {
-  log as l
-};
-",
-    "dynamicImports": [],
-    "exports": [
-      "l",
-    ],
-    "facadeModuleId": null,
-    "fileName": "assets/log.js",
-    "implicitlyLoadedBefore": [],
-    "importedBindings": {},
-    "imports": [],
-    "isDynamicEntry": false,
-    "isEntry": false,
-    "isImplicitEntry": false,
-    "map": null,
-    "modules": {
-      "vite-plugin-web-extension/test/manifest/resources/shared/log.js": {
-        "code": "function log(message) {
-  console.log(message);
-}",
-        "originalLength": 65,
-        "removedExports": [],
-        "renderedExports": [
-          "default",
-        ],
-        "renderedLength": 49,
-      },
-    },
-    "name": "log",
-    "referencedFiles": [],
-    "type": "chunk",
-    "viteMetadata": {
-      "importedAssets": Set {},
-      "importedCss": Set {},
-    },
-  },
-  {
-    "fileName": "test/manifest/resources/useDynamicUrlWebAccessibleResources/script1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/useDynamicUrlWebAccessibleResources/script1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/useDynamicUrlWebAccessibleResources/script2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/useDynamicUrlWebAccessibleResources/script2.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/useDynamicUrlWebAccessibleResources/content1.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/useDynamicUrlWebAccessibleResources/content1.js\\"))})();",
-    "type": "asset",
-  },
-  {
-    "fileName": "test/manifest/resources/useDynamicUrlWebAccessibleResources/content2.js",
-    "name": undefined,
-    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/useDynamicUrlWebAccessibleResources/content2.js\\"))})();",
-    "type": "asset",
-  },
-  {
     "fileName": "manifest.json",
     "name": undefined,
     "source": "{
@@ -263,6 +239,30 @@ export {
     }
   ]
 }",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/useDynamicUrlWebAccessibleResources/content1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/useDynamicUrlWebAccessibleResources/content1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/useDynamicUrlWebAccessibleResources/content2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/useDynamicUrlWebAccessibleResources/content2.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/useDynamicUrlWebAccessibleResources/script1.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/useDynamicUrlWebAccessibleResources/script1.js\\"))})();",
+    "type": "asset",
+  },
+  {
+    "fileName": "test/manifest/resources/useDynamicUrlWebAccessibleResources/script2.js",
+    "name": undefined,
+    "source": "(async()=>{await import(chrome.runtime.getURL(\\"assets/test/manifest/resources/useDynamicUrlWebAccessibleResources/script2.js\\"))})();",
     "type": "asset",
   },
 ]

--- a/test/manifest/manifestTestUtils.ts
+++ b/test/manifest/manifestTestUtils.ts
@@ -63,50 +63,52 @@ export async function runTest<ManifestType extends chrome.runtime.Manifest>({
   });
 
   expect(
-    output.map((file) => {
-      if (file.type === "chunk") {
-        const modules = {};
-        for (const [key, value] of Object.entries(file.modules)) {
-          modules[trimFilePathToRepoDirectory(key)] = value;
+    output
+      .map((file) => {
+        if (file.type === "chunk") {
+          const modules = {};
+          for (const [key, value] of Object.entries(file.modules)) {
+            modules[trimFilePathToRepoDirectory(key)] = value;
+          }
+
+          return {
+            code: file.code,
+            dynamicImports: file.dynamicImports,
+            exports: file.exports,
+            facadeModuleId: file.facadeModuleId
+              ? trimFilePathToRepoDirectory(file.facadeModuleId)
+              : null,
+            fileName: normalizeFileName(file.fileName),
+            implicitlyLoadedBefore: file.implicitlyLoadedBefore,
+            importedBindings: file.importedBindings,
+            imports: file.imports,
+            isDynamicEntry: file.isDynamicEntry,
+            isEntry: file.isEntry,
+            isImplicitEntry: file.isImplicitEntry,
+            map: file.map,
+            modules: modules,
+            name: normalizeFileName(file.name),
+            referencedFiles: file.referencedFiles,
+            type: file.type,
+            viteMetadata: file.viteMetadata,
+          };
         }
 
-        return {
-          code: file.code,
-          dynamicImports: file.dynamicImports,
-          exports: file.exports,
-          facadeModuleId: file.facadeModuleId
-            ? trimFilePathToRepoDirectory(file.facadeModuleId)
-            : null,
-          fileName: normalizeFileName(file.fileName),
-          implicitlyLoadedBefore: file.implicitlyLoadedBefore,
-          importedBindings: file.importedBindings,
-          imports: file.imports,
-          isDynamicEntry: file.isDynamicEntry,
-          isEntry: file.isEntry,
-          isImplicitEntry: file.isImplicitEntry,
-          map: file.map,
-          modules: modules,
-          name: normalizeFileName(file.name),
-          referencedFiles: file.referencedFiles,
-          type: file.type,
-          viteMetadata: file.viteMetadata,
-        };
-      }
+        if (file.type === "asset") {
+          return {
+            fileName: normalizeFileName(file.fileName),
+            name:
+              typeof file.name === "undefined"
+                ? undefined
+                : normalizeFileName(file.name),
+            source: file.source,
+            type: file.type,
+          };
+        }
 
-      if (file.type === "asset") {
-        return {
-          fileName: normalizeFileName(file.fileName),
-          name:
-            typeof file.name === "undefined"
-              ? undefined
-              : normalizeFileName(file.name),
-          source: file.source,
-          type: file.type,
-        };
-      }
-
-      return file;
-    })
+        return file;
+      })
+      .sort((a, b) => a.fileName.localeCompare(b.fileName))
   ).toMatchSnapshot();
 }
 


### PR DESCRIPTION
multiple HTML files as input do not get output in a deterministic way
