### PR TITLE
refactor(hmr): inject entire vite client instead of just env file

### DIFF
--- a/src/devBuilder/devBuilderManifestV3.ts
+++ b/src/devBuilder/devBuilderManifestV3.ts
@@ -28,7 +28,7 @@ export default class DevBuilderManifestV3 extends DevBuilder<chrome.runtime.Mani
     const fileName = manifest.background?.service_worker;
 
     const serviceWorkerLoader = getServiceWorkerLoaderFile([
-      this.hmrViteEnvFileUrl,
+      this.hmrViteClientUrl,
       `${this.hmrServerOrigin}/${fileName}`,
     ]);
 


### PR DESCRIPTION
also inject vite client in html when devHtmlTransform is turned off