### PR TITLE
refactor(hmr): rework HTML dev server url rewrites

### DIFF
--- a/src/manifestParser/manifestParser.ts
+++ b/src/manifestParser/manifestParser.ts
@@ -3,6 +3,7 @@ import type {
   OutputAsset,
   OutputBundle,
   OutputChunk,
+  PluginContext,
 } from "rollup";
 import { ResolvedConfig, ViteDevServer } from "vite";
 import type {
@@ -61,10 +62,14 @@ export default abstract class ManifestParser<
     );
   }
 
-  async writeDevBuild(devServerPort: number): Promise<void> {
+  async writeDevBuild(
+    devServerPort: number,
+    resolveImport: PluginContext["resolve"]
+  ): Promise<void> {
     await this.createDevBuilder().writeBuild({
       devServerPort,
       manifestHtmlFiles: this.getHtmlFileNames(this.inputManifest),
+      resolveImport,
     });
   }
 

--- a/src/utils/checkPublicFile.ts
+++ b/src/utils/checkPublicFile.ts
@@ -1,0 +1,26 @@
+import path from "node:path";
+import fs from "node:fs";
+import type { ResolvedConfig } from "vite";
+import cleanUrl from "./cleanUrl";
+
+// copied from vite
+export default function checkPublicFile(
+  url: string,
+  { publicDir }: ResolvedConfig
+): string | undefined {
+  // note if the file is in /public, the resolver would have returned it
+  // as-is so it's not going to be a fully resolved path.
+  if (!publicDir || url[0] !== "/") {
+    return;
+  }
+  const publicFile = path.join(publicDir, cleanUrl(url));
+  if (!publicFile.startsWith(publicDir)) {
+    // can happen if URL starts with '../'
+    return;
+  }
+  if (fs.existsSync(publicFile)) {
+    return publicFile;
+  } else {
+    return;
+  }
+}

--- a/src/utils/cleanUrl.ts
+++ b/src/utils/cleanUrl.ts
@@ -1,0 +1,5 @@
+const postfixRE = /[?#].*$/s;
+
+export default function cleanUrl(url: string): string {
+  return url.replace(postfixRE, "");
+}

--- a/src/utils/isDataUrl.ts
+++ b/src/utils/isDataUrl.ts
@@ -1,0 +1,5 @@
+const dataUrlRE = /^\s*data:/i;
+
+export default function isExternalUrl(url: string): boolean {
+  return dataUrlRE.test(url);
+}

--- a/src/utils/isExternalUrl.ts
+++ b/src/utils/isExternalUrl.ts
@@ -1,0 +1,5 @@
+const externalRE = /^(https?:)?\/\//;
+
+export default function isExternalUrl(url: string): boolean {
+  return externalRE.test(url);
+}


### PR DESCRIPTION
makes it closer to Vite: resolves paths using rollups resolver which adds support for loading resources from workspace packages and adds logic to prevent rewriting urls for things not served by dev server