### PR TITLE
refactor(devBuilder)!: always use transformIndexHtml for HTML processing

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,8 +1,13 @@
 # Migration
 
+- [Version 4.x.x to 5.0.0](#version-4xx-to-500)
 - [Version 3.x.x to 4.0.0](#version-3xx-to-400)
 - [Version 2.x.x to 3.0.0](#version-2xx-to-300)
 - [Version 0.x.x to 1.0.0](#version-0xx-to-100)
+
+## Version 4.x.x to 5.0.0
+
+- The `devHtmlTransform` plugin option has been removed. Vite's dev HTML transform functionality is now required to support HTML files in dev (HMR) mode. In dev mode, a <base> element with the dev server url for the HTML file is injected into the page. This replaces incomplete custom logic for handling resources in HTML files.
 
 ## Version 3.x.x to 4.0.0
 

--- a/README.md
+++ b/README.md
@@ -174,12 +174,6 @@ optimizeWebAccessibleResources (optional)
 - Default: `true`
 - On build, in Manifest V3, merge web accessible resource definitions that have matching non-`resource` properties and dedupe and sort `resources`. In Manifest V2, sort web accessible resources.
 
-devHtmlTransform (optional)
-
-- Type: `boolean`
-- Default: `false`
-- In dev mode, apply Vite plugins to manifest HTML files by calling transformIndexHtml on them
-
 additionalInputs (optional)
 
 - Type:

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -43,12 +43,6 @@ interface ViteWebExtensionOptions {
   optimizeWebAccessibleResources?: boolean;
 
   /**
-   * In dev mode, apply Vite plugins to manifest HTML files by calling transformIndexHtml on them
-   * Default: false
-   */
-  devHtmlTransform?: boolean;
-
-  /**
    * Additional input files that should be processed and treated as web extension inputs.
    * Useful for dynamically injected scripts and dynamically opened HTML pages.
    * The webAccessible option configures whether the entry file and its dependencies are included in the manifest `web_accessible_resources` property. Defaults to true.


### PR DESCRIPTION
The `devHtmlTransform` plugin option has been removed. Vite's dev HTML transform functionality is now required to support HTML files in dev (HMR) mode. In dev mode, a `<base>` element with the dev server url for the HTML file is injected into the page. This replaces incomplete custom logic for handling resources in HTML files.