### PR TITLE
feat: do not build public files

### DIFF
--- a/src/devBuilder/devBuilder.ts
+++ b/src/devBuilder/devBuilder.ts
@@ -58,12 +58,6 @@ export default abstract class DevBuilder<
     this.hmrViteClientUrl = `${this.hmrServerOrigin}/@vite/client`;
 
     await emptyDir(this.outDir);
-    const publicDir = path.resolve(
-      process.cwd(),
-      this.viteConfig.root,
-      this.viteConfig.publicDir
-    );
-    await copy(publicDir, this.outDir);
 
     await this.writeManifestHtmlFiles(manifestHtmlFiles);
     await this.writeManifestContentScriptFiles();
@@ -71,6 +65,13 @@ export default abstract class DevBuilder<
     await this.writeManifestAdditionalInputFiles();
 
     await this.writeBuildFiles(manifestHtmlFiles);
+
+    const publicDir = path.resolve(
+      process.cwd(),
+      this.viteConfig.root,
+      this.viteConfig.publicDir
+    );
+    await copy(publicDir, this.outDir);
 
     this.updateContentSecurityPolicyForHmr();
 


### PR DESCRIPTION
I have a pre-compiled js file under public folder, which is included in the content_scripts of the manifest file. However, `writeBuild` will overwrite it.