### PR TITLE
feat: support for safari web extensions

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,9 +1,13 @@
 import typescript from "@rollup/plugin-typescript";
 import pkg from "./package.json" assert { type: "json" };
 
-const external = ["node:crypto", "node:fs/promises", "node:path"].concat(
-  Object.keys(pkg.dependencies ?? {})
-);
+const external = [
+  "node:child_process",
+  "node:crypto",
+  "node:fs/promises",
+  "node:os",
+  "node:path",
+].concat(Object.keys(pkg.dependencies ?? {}));
 
 export default {
   input: "src/index.ts",

--- a/src/utils/convertToSafariWebExtension.ts
+++ b/src/utils/convertToSafariWebExtension.ts
@@ -1,0 +1,117 @@
+import os from "node:os";
+import fs from "fs-extra";
+import { spawn } from "node:child_process";
+import { SafariBuildOptions } from "../../types";
+
+export async function convertToSafariWebExtension(
+  dist: string,
+  {
+    dir = undefined,
+    appName = "web-extension",
+    bundleIdentifier = "",
+    objc = false,
+  }: SafariBuildOptions = {}
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    spawn("which", ["xcrun"]).on("close", (code) =>
+      code ? reject("Xcode Command Line Tools are not available") : resolve()
+    );
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    spawn("which", ["xcodebuild"]).on("close", (code) =>
+      code ? reject("Xcode Command Line Tools are not available") : resolve()
+    );
+  });
+
+  const outputPath = dir
+    ? `${dist.split("/").slice(0, -1).join("/")}/${dir}`
+    : `${dist}-safari`;
+
+  const projectLocation = `${os.tmpdir()}/vite-plugin-web-extension-safari-${Date.now()}-${~~(
+    Math.random() * 1000000
+  )}`;
+
+  await fs.remove(projectLocation);
+  await fs.ensureDir(projectLocation);
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const cp = spawn(
+        "xcrun",
+        [
+          "safari-web-extension-converter",
+          "--no-open",
+          "--copy-resources",
+          "--macos-only",
+          "--project-location",
+          projectLocation,
+          "--app-name",
+          appName,
+          objc ? "--objc" : "--swift",
+          ...(bundleIdentifier
+            ? ["--bundle-identifier", bundleIdentifier]
+            : []),
+          dist,
+        ],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+        }
+      );
+
+      let error = "";
+
+      cp.stderr.on("data", (data) => {
+        error += data;
+      });
+
+      cp.on("close", (code) => (code ? reject(error) : resolve()));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const cp = spawn(
+        "xcodebuild",
+        [
+          "-project",
+          `${projectLocation}/${appName}/${appName}.xcodeproj`,
+          "-scheme",
+          appName,
+          "-configuration",
+          "Release",
+          `SYMROOT=${projectLocation}`,
+          "build",
+        ],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+        }
+      );
+
+      let error = "";
+
+      const onClose = (code: number) => (code ? reject(error) : resolve());
+
+      const onData = (data: string) => {
+        error += data;
+
+        if (error.includes("** BUILD FAILED **")) {
+          cp.kill();
+          onClose(1);
+        }
+      };
+
+      cp.stdout.on("data", onData);
+      cp.stderr.on("data", onData);
+      cp.on("close", onClose);
+    });
+
+    await fs.remove(outputPath);
+    await fs.ensureDir(outputPath);
+
+    await fs.copy(
+      `${projectLocation}/Release/${appName}.app`,
+      `${outputPath}/${appName}.app`
+    );
+  } finally {
+    await fs.remove(projectLocation);
+  }
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -43,6 +43,12 @@ interface ViteWebExtensionOptions {
   optimizeWebAccessibleResources?: boolean;
 
   /**
+   * Enables and configures Safari build.
+   * Default: false
+   */
+  safari?: boolean | SafariBuildOptions;
+
+  /**
    * Additional input files that should be processed and treated as web extension inputs.
    * Useful for dynamically injected scripts and dynamically opened HTML pages.
    * The webAccessible option configures whether the entry file and its dependencies are included in the manifest `web_accessible_resources` property. Defaults to true.
@@ -60,6 +66,32 @@ interface ViteWebExtensionOptions {
     html?: AdditionalInput[];
     styles?: AdditionalInput[];
   };
+}
+
+export interface SafariBuildOptions {
+  /**
+   * Safari extension build output
+   * Default: vite output dir with a `-safari` suffix
+   */
+  dir?: string;
+
+  /**
+   * Name of the app
+   * Default: name provided in the manifest
+   */
+  appName?: string;
+
+  /**
+   * Bundle identifier to build the app with
+   * Default: undefined
+   */
+  bundleIdentifier?: string;
+
+  /**
+   * Build the app using objective-c instead of swift
+   * Default: false
+   */
+  objc?: boolean;
 }
 
 /**


### PR DESCRIPTION
I'm not sure this falls within the scope of this plugin, but for my own use I implemented an additional build process to create Safari web extensions. It relies on the xcode command line tools to convert the existing output to a macOS app embedding the extension. It is generated during the `writeBundle` hook, and outputted aside the original dist folder.

I believe my addition isn't that clean neither bulletproof right now, but it could be a starting point if you want to provide this feature.