### PR TITLE
Only use the httpServer if it exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export default function webExtension(
     configureServer(server) {
       server.middlewares.use(viteClientModifier);
 
-      server.httpServer!.once("listening", () => {
+      server.httpServer?.once("listening", () => {
         manifestParser.setDevServer(server);
         manifestParser.writeDevBuild(server.config.server.port!);
       });


### PR DESCRIPTION
`server.httpServer` will be null if this is running in middleware mode.
https://vitejs.dev/guide/api-javascript#vitedevserver

Fail gracefully if `server.httpServer` is null. This is problematic when running tests

```
$ vite-jest --forceExit
Building manifest for chrome
● Validation Error:

  Preset ./node_modules/vite-jest/index.js is invalid:

  Cannot read properties of null (reading 'once')
  TypeError: Cannot read properties of null (reading 'once')
    at configureServer (/Users/username/workspace/my-project/node_modules/@samrum/vite-plugin-web-extension/dist/index.cjs:1048:31)
    at _createServer (file:///Users/username/workspace/my-project/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:63461:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async file:///Users/username/workspace/my-project/node_modules/vite-jest/vite-server.js:5:20

  Configuration Documentation:
  https://jestjs.io/docs/configuration

/Users/nathancook/workspace/ncontext-extension/node_modules/execa/lib/error.js:60
		error = new Error(message);
```